### PR TITLE
Search for robot_description upwards in namespaces

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -76,9 +76,14 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   KDL::Chain  robot_chain;
 
   // Get controller specific configuration
-  if (!nh.getParam("/robot_description",robot_description))
+  if (!ros::param::search("robot_description", robot_description))
   {
-    ROS_ERROR("Failed to load '/robot_description' from parameter server");
+    ROS_ERROR_STREAM("Searched enclosing namespaces for robot_description but nothing found");
+    return false;
+  }
+  if (!nh.getParam(robot_description, robot_description))
+  {
+    ROS_ERROR_STREAM("Failed to load " << robot_description << " from parameter server");
     return false;
   }
   if (!nh.getParam("robot_base_link",m_robot_base_link))

--- a/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.hpp
+++ b/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.hpp
@@ -99,9 +99,14 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   KDL::Tree   robot_tree;
 
   // Get configuration from parameter server
-  if (!nh.getParam("/robot_description",robot_description))
+  if (!ros::param::search("robot_description", robot_description))
   {
-    ROS_ERROR("Failed to load '/robot_description' from parameter server");
+    ROS_ERROR_STREAM("Searched enclosing namespaces for robot_description but nothing found");
+    return false;
+  }
+  if (!nh.getParam(robot_description, robot_description))
+  {
+    ROS_ERROR_STREAM("Failed to load " << robot_description << " from parameter server");
     return false;
   }
   if (!nh.getParam("robot_base_link",m_robot_base_link))


### PR DESCRIPTION
This allows controllers to use local robot_descriptions and supports
to control various robots in parallel through namespacing.

Fixes #12
Fixes #13 