### PR TITLE
Add ROS industrial ci

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  industrial_ci:
+    strategy:
+      matrix:
+        env:
+          - {ROS_DISTRO: melodic, ROS_REPO: testing}
+          - {ROS_DISTRO: melodic, ROS_REPO: main}
+          - {ROS_DISTRO: noetic, ROS_REPO: testing}
+          - {ROS_DISTRO: noetic, ROS_REPO: main}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: 'ros-industrial/industrial_ci@master'
+        env: ${{matrix.env}}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![build badge](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/actions/workflows/industrial_ci_action.yml/badge.svg)
+
 # Cartesian Controllers
 This package provides libraries with Cartesian ROS controllers.
 


### PR DESCRIPTION
## Goal
It's about time that the `cartesian_controllers` get additional testing. Let's add Github actions to our *internal* pipelines and continue the main development here.

## Steps
- [x] Configure CI
- [x] Check that things work as expected
- [x] Add build badges to toplevel README.md