### PR TITLE
Replace boost with the std equivalent

### DIFF
--- a/cartesian_compliance_controller/CMakeLists.txt
+++ b/cartesian_compliance_controller/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_compliance_controller)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.h
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.h
@@ -110,7 +110,7 @@ class CartesianComplianceController
 
     void dynamicReconfigureCallback(ComplianceConfig& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<ComplianceConfig> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<ComplianceConfig> > m_dyn_conf_server;
     dynamic_reconfigure::Server<ComplianceConfig>::CallbackType m_callback_type;
 };
 

--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
@@ -44,7 +44,7 @@
 #include <cartesian_compliance_controller/cartesian_compliance_controller.h>
 
 // Other
-#include <boost/algorithm/clamp.hpp>
+#include <algorithm>
 #include <map>
 
 namespace cartesian_compliance_controller
@@ -81,8 +81,8 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   // Connect dynamic reconfigure and overwrite the default values with values
   // on the parameter server. This is done automatically if parameters with
   // the according names exist.
-  m_callback_type = boost::bind(
-      &CartesianComplianceController<HardwareInterface>::dynamicReconfigureCallback, this, _1, _2);
+  m_callback_type = std::bind(
+      &CartesianComplianceController<HardwareInterface>::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2);
 
   m_dyn_conf_server.reset(
       new dynamic_reconfigure::Server<ComplianceConfig>(

--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_controller_base)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
@@ -103,7 +103,7 @@ class DampedLeastSquaresSolver : public IKSolver
               const KDL::JntArray& lower_pos_limits);
 
   private:
-    boost::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
+    std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
     KDL::Jacobian m_jnt_jacobian;
     double m_alpha;
 
@@ -113,7 +113,7 @@ class DampedLeastSquaresSolver : public IKSolver
 
     void dynamicReconfigureCallback(IKConfig& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<IKConfig> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<IKConfig> > m_dyn_conf_server;
     dynamic_reconfigure::Server<IKConfig>::CallbackType m_callback_type;
 };
 

--- a/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
@@ -58,7 +58,7 @@
 
 // other
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // KDL
 #include <kdl/frames.hpp>
@@ -129,8 +129,8 @@ class ForwardDynamicsSolver : public IKSolver
     bool buildGenericModel();
 
     // Forward dynamics
-    boost::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
-    boost::shared_ptr<KDL::ChainDynParam>       m_jnt_space_inertia_solver;
+    std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
+    std::shared_ptr<KDL::ChainDynParam>       m_jnt_space_inertia_solver;
     KDL::Jacobian                               m_jnt_jacobian;
     KDL::JntSpaceInertiaMatrix                  m_jnt_space_inertia;
 
@@ -141,7 +141,7 @@ class ForwardDynamicsSolver : public IKSolver
 
     void dynamicReconfigureCallback(IKConfig& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<IKConfig> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<IKConfig> > m_dyn_conf_server;
     dynamic_reconfigure::Server<IKConfig>::CallbackType m_callback_type;
 };
 

--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -53,7 +53,7 @@
 
 // other
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // KDL
 #include <kdl/frames.hpp>
@@ -189,9 +189,9 @@ class IKSolver
     KDL::JntArray m_lower_pos_limits;
 
     // Forward kinematics
-    boost::shared_ptr<
+    std::shared_ptr<
       KDL::ChainFkSolverPos_recursive>  m_fk_pos_solver;
-    boost::shared_ptr<
+    std::shared_ptr<
       KDL::ChainFkSolverVel_recursive>  m_fk_vel_solver;
     KDL::Frame                          m_end_effector_pose;
     ctrl::Vector6D                      m_end_effector_vel;

--- a/cartesian_controller_base/include/cartesian_controller_base/JacobianTransposeSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/JacobianTransposeSolver.h
@@ -96,7 +96,7 @@ class JacobianTransposeSolver : public IKSolver
               const KDL::JntArray& lower_pos_limits);
 
   private:
-    boost::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
+    std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
     KDL::Jacobian m_jnt_jacobian;
 };
 

--- a/cartesian_controller_base/include/cartesian_controller_base/PDController.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/PDController.h
@@ -104,7 +104,7 @@ class PDController
     typedef cartesian_controller_base::PDGainsConfig PDGainsConfig;
     void dynamicReconfigureCallback(PDGainsConfig& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<PDGainsConfig> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<PDGainsConfig> > m_dyn_conf_server;
     dynamic_reconfigure::Server<PDGainsConfig>::CallbackType m_callback_type;
 
 };

--- a/cartesian_controller_base/include/cartesian_controller_base/SelectivelyDampedLeastSquaresSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/SelectivelyDampedLeastSquaresSolver.h
@@ -115,7 +115,7 @@ class SelectivelyDampedLeastSquaresSolver : public IKSolver
     Eigen::Matrix<double, Eigen::Dynamic, 1>
     clampMaxAbs(const Eigen::Matrix<double, Eigen::Dynamic, 1>& w, double d);
 
-    boost::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
+    std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
     KDL::Jacobian m_jnt_jacobian;
 
 };

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -149,13 +149,13 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      */
     ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
 
-    boost::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
+    std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
 
     /**
      * @brief Allow users to choose the IK solver type on startup
      */
-    boost::shared_ptr<pluginlib::ClassLoader<IKSolver> > m_solver_loader;
-    boost::shared_ptr<IKSolver> m_ik_solver;
+    std::shared_ptr<pluginlib::ClassLoader<IKSolver> > m_solver_loader;
+    std::shared_ptr<IKSolver> m_ik_solver;
 
     std::string m_end_effector_link;
     std::string m_robot_base_link;
@@ -179,7 +179,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
 
     void dynamicReconfigureCallback(ControllerConfig& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<ControllerConfig> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<ControllerConfig> > m_dyn_conf_server;
     dynamic_reconfigure::Server<ControllerConfig>::CallbackType m_callback_type;
 };
 

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -80,7 +80,7 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     "cartesian_controller_base", "cartesian_controller_base::IKSolver"));
   try
   {
-    m_ik_solver = m_solver_loader->createInstance(ik_solver);
+    m_ik_solver = m_solver_loader->createUniqueInstance(ik_solver);
   }
   catch (pluginlib::PluginlibException& ex)
   {
@@ -191,8 +191,8 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   // the according names exist.
   m_error_scale = 1.0;
   m_iterations = 1;
-  m_callback_type = boost::bind(
-      &CartesianControllerBase<HardwareInterface>::dynamicReconfigureCallback, this, _1, _2);
+  m_callback_type = std::bind(
+      &CartesianControllerBase<HardwareInterface>::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2);
 
   m_dyn_conf_server.reset(
       new dynamic_reconfigure::Server<ControllerConfig>(

--- a/cartesian_controller_examples/CMakeLists.txt
+++ b/cartesian_controller_examples/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_controller_examples)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_controller_handles/CMakeLists.txt
+++ b/cartesian_controller_handles/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_controller_handles)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.h
+++ b/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.h
@@ -50,7 +50,7 @@
 #include <hardware_interface/joint_state_interface.h>
 
 // Other
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // KDL
 #include <kdl/chain.hpp>
@@ -156,14 +156,14 @@ class MotionControlHandle : public controller_interface::Controller<HardwareInte
     std::string   m_end_effector_link;
     std::string   m_target_frame_topic;
     KDL::Chain    m_robot_chain;
-    boost::shared_ptr<
+    std::shared_ptr<
       KDL::ChainFkSolverPos_recursive>  m_fk_solver;
 
     geometry_msgs::PoseStamped  m_current_pose;
     ros::Publisher  m_pose_publisher;
 
     // Interactive marker
-    boost::shared_ptr<
+    std::shared_ptr<
       interactive_markers::InteractiveMarkerServer> m_server;
 
     visualization_msgs::InteractiveMarker           m_marker; //!< Controller handle for RViz

--- a/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.hpp
+++ b/cartesian_controller_handles/include/cartesian_controller_handles/MotionControlHandle.hpp
@@ -184,13 +184,13 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   // Add callback for motion in RViz
   m_server->setCallback(
       m_marker.name,
-      boost::bind(&MotionControlHandle::updateMotionControlCallback,this,_1),
+      std::bind(&MotionControlHandle::updateMotionControlCallback,this,std::placeholders::_1),
       visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE);
 
   // Add callback for menu interaction in RViz
   m_server->setCallback(
       m_marker.name,
-      boost::bind(&MotionControlHandle::updateMarkerMenuCallback,this,_1),
+      std::bind(&MotionControlHandle::updateMarkerMenuCallback,this,std::placeholders::_1),
       visualization_msgs::InteractiveMarkerFeedback::MENU_SELECT);
 
   // Activate configuration

--- a/cartesian_force_controller/CMakeLists.txt
+++ b/cartesian_force_controller/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_force_controller)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -134,7 +134,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
 
     void dynamicReconfigureCallback(Config& config, uint32_t level);
 
-    boost::shared_ptr<dynamic_reconfigure::Server<Config> > m_dyn_conf_server;
+    std::shared_ptr<dynamic_reconfigure::Server<Config> > m_dyn_conf_server;
     dynamic_reconfigure::Server<Config>::CallbackType m_callback_type;
 };
 

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -45,7 +45,7 @@
 #include <cartesian_force_controller/cartesian_force_controller.h>
 
 // Other
-#include <boost/algorithm/clamp.hpp>
+#include <algorithm>
 
 namespace cartesian_force_controller
 {
@@ -107,8 +107,8 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   // Connect dynamic reconfigure and overwrite the default values with values
   // on the parameter server. This is done automatically if parameters with
   // the according names exist.
-  m_callback_type = boost::bind(
-      &CartesianForceController::dynamicReconfigureCallback, this, _1, _2);
+  m_callback_type = std::bind(
+      &CartesianForceController::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2);
 
   m_dyn_conf_server.reset(
       new dynamic_reconfigure::Server<Config>(nh));

--- a/cartesian_motion_controller/CMakeLists.txt
+++ b/cartesian_motion_controller/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(cartesian_motion_controller)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.hpp
+++ b/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.hpp
@@ -44,7 +44,7 @@
 #include <cartesian_motion_controller/cartesian_motion_controller.h>
 
 // Other
-#include <boost/algorithm/clamp.hpp>
+#include <algorithm>
 
 namespace cartesian_motion_controller
 {
@@ -168,8 +168,8 @@ computeMotionError()
   // The remaining error will be handled in the next control cycle.
   const double max_angle = 1.0;
   const double max_distance = 1.0;
-  angle    = boost::algorithm::clamp(angle,-max_angle,max_angle);
-  distance = boost::algorithm::clamp(distance,-max_distance,max_distance);
+  angle    = std::clamp(angle,-max_angle,max_angle);
+  distance = std::clamp(distance,-max_distance,max_distance);
 
   // Scale errors to allowed magnitudes
   rot_axis = rot_axis * angle;

--- a/joint_to_cartesian_controller/CMakeLists.txt
+++ b/joint_to_cartesian_controller/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(joint_to_cartesian_controller)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
+add_compile_options(-std=c++17)
 
 set(ADDITIONAL_COMPILE_OPTIONS -Wall -Wextra -Wpedantic -Wno-unused-parameter)
 add_compile_options(${ADDITIONAL_COMPILE_OPTIONS})

--- a/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
+++ b/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
@@ -103,10 +103,10 @@ class JointToCartesianController
     std::vector<
       hardware_interface::JointStateHandle>   m_joint_handles;
 
-    boost::shared_ptr<
+    std::shared_ptr<
       KDL::ChainFkSolverPos_recursive>        m_fk_solver;
 
-    boost::shared_ptr<
+    std::shared_ptr<
       controller_manager::ControllerManager>  m_controller_manager;
 
 };


### PR DESCRIPTION
## Goal
Remove the boost dependency from this code base. I hope that's helpful in avoiding incompatibilities with user-side Boost versions and is easier to maintain in the future.

## Steps
- [x] Replace `boost` with `std` equivalents
- [x] Check if everything works as expected (requires tests)
- [x] Check if `std::clamp` is worth the `c++17` flag. (It's only used in one place)