### PR TITLE
Add basic integration tests

### DIFF
--- a/cartesian_controller_examples/CMakeLists.txt
+++ b/cartesian_controller_examples/CMakeLists.txt
@@ -184,6 +184,16 @@ include_directories(
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
 
+# We build our integration tests on the example.launch,
+# so make sure each component is installed.
+install(DIRECTORY
+  config
+  etc
+  launch
+  urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 #############
 ## Testing ##
 #############

--- a/cartesian_controller_examples/etc/examples.rviz
+++ b/cartesian_controller_examples/etc/examples.rviz
@@ -4,13 +4,10 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Global Options1
-        - /Status1
-        - /TF1
         - /TF1/Frames1
         - /RobotModel1/Links1
-      Splitter Ratio: 0.511482
-    Tree Height: 747
+      Splitter Ratio: 0.5114820003509521
+    Tree Height: 455
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -19,7 +16,7 @@ Panels:
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
-    Splitter Ratio: 0.588679016
+    Splitter Ratio: 0.5886790156364441
   - Class: rviz/Views
     Expanded:
       - /Current View1
@@ -30,6 +27,8 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
 Toolbars:
   toolButtonStyle: 2
 Visualization Manager:
@@ -41,7 +40,7 @@ Visualization Manager:
       Color: 160; 160; 164
       Enabled: true
       Line Style:
-        Line Width: 0.0299999993
+        Line Width: 0.029999999329447746
         Value: Lines
       Name: Grid
       Normal Cell Count: 0
@@ -78,7 +77,8 @@ Visualization Manager:
           Value: true
         world:
           Value: true
-      Marker Scale: 0.300000012
+      Marker Alpha: 1
+      Marker Scale: 0.30000001192092896
       Name: TF
       Show Arrows: false
       Show Axes: true
@@ -163,42 +163,30 @@ Visualization Manager:
       Value: true
       Visual Enabled: true
     - Alpha: 1
-      Arrow Width: 0.5
-      Class: rviz/WrenchStamped
-      Enabled: true
-      Force Arrow Scale: 2
-      Force Color: 204; 51; 51
-      History Length: 1
-      Name: WrenchStamped
-      Topic: /damping_force
-      Torque Arrow Scale: 2
-      Torque Color: 204; 204; 51
-      Unreliable: false
-      Value: true
-    - Alpha: 1
-      Axes Length: 0.0700000003
-      Axes Radius: 0.00999999978
+      Axes Length: 0.07000000029802322
+      Axes Radius: 0.009999999776482582
       Class: rviz/Pose
       Color: 255; 25; 0
       Enabled: true
-      Head Length: 0.300000012
-      Head Radius: 0.100000001
+      Head Length: 0.30000001192092896
+      Head Radius: 0.10000000149011612
       Name: Pose
+      Queue Size: 10
       Shaft Length: 1
-      Shaft Radius: 0.0500000007
+      Shaft Radius: 0.05000000074505806
       Shape: Axes
-      Topic: /my_cartesian_motion_controller/target_frame
+      Topic: /target_frame
       Unreliable: false
       Value: true
     - Class: rviz/InteractiveMarkers
       Enable Transparency: false
-      Enabled: false
+      Enabled: true
       Name: InteractiveMarkers
       Show Axes: true
       Show Descriptions: false
       Show Visual Aids: false
       Update Topic: /my_motion_control_handle/update
-      Value: false
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 116; 116; 116
@@ -214,7 +202,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -224,33 +215,33 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 2.64989567
+      Distance: 2.649895668029785
       Enable Stereo Rendering:
-        Stereo Eye Separation: 0.0599999987
+        Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Field of View: 0.7853981852531433
       Focal Point:
-        X: -0.0034658527
-        Y: -0.304883659
-        Z: 0.146290645
+        X: -0.003465852700173855
+        Y: -0.3048836588859558
+        Z: 0.1462906450033188
       Focal Shape Fixed Size: true
-      Focal Shape Size: 0.0500000007
+      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
-      Near Clip Distance: 0.00999999978
-      Pitch: 0.294797003
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.29479700326919556
       Target Frame: <Fixed Frame>
-      Value: Orbit (rviz)
-      Yaw: 0.870410562
+      Yaw: 0.8704105615615845
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1028
+  Height: 752
   Hide Left Dock: false
   Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001e10000037afc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c00610079007301000000280000037a000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002dcfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002dc000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007470000003efc0100000002fb0000000800540069006d00650100000000000007470000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000005600000037a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000252fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000252000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002dcfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002dc000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005700000003efc0100000002fb0000000800540069006d0065010000000000000570000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004140000025200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -259,6 +250,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1863
-  X: 57
-  Y: 24
+  Width: 1392
+  X: 319
+  Y: 135

--- a/cartesian_controller_examples/launch/examples.launch
+++ b/cartesian_controller_examples/launch/examples.launch
@@ -1,5 +1,6 @@
 <launch>
         <!-- Configuration -->
+        <arg name="rviz" default="true"/>
         <arg name="debug" default="false"/>
         <arg if="$(arg debug)" name="launch-prefix" value="screen -d -m gdb -command=$(env HOME)/.ros/my_debug_log --ex run --args"/>
         <arg unless="$(arg debug)" name="launch-prefix" value=""/>
@@ -12,7 +13,17 @@
         <rosparam file="$(find cartesian_controller_examples)/config/example_hw_config.yaml" command="load"></rosparam>
 
         <!-- Load hardware interface -->
-        <node name="sim_hardware_interface" pkg="ros_control_boilerplate" type="sim_hw_main" output="screen" launch-prefix="$(arg launch-prefix)"/>
+        <node name="sim_hardware_interface" pkg="ros_control_boilerplate" type="sim_hw_main" output="screen" launch-prefix="$(arg launch-prefix)">
+
+                <!-- Control motion and compliance controller with one handle -->
+                <remap from="my_motion_control_handle/target_frame" to="target_frame" />
+                <remap from="my_cartesian_motion_controller/target_frame" to="target_frame" />
+                <remap from="my_cartesian_compliance_controller/target_frame" to="target_frame" />
+
+                <!-- Control wrenches via one topic -->
+                <remap from="my_cartesian_force_controller/target_wrench" to="target_wrench" />
+                <remap from="my_cartesian_compliance_controller/target_wrench" to="target_wrench" />
+        </node>
 
         <!-- Robot state publisher -->
         <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
@@ -45,7 +56,8 @@
         </group>
 
         <!-- Visualization -->
-        <arg name="my_rviz" value="-d $(find cartesian_controller_examples)/etc/examples.rviz" />
-        <node name="rviz" pkg="rviz" type="rviz" respawn="false" args="$(arg my_rviz)" output="screen" >
-        </node>
+        <group if="$(arg rviz)">
+                <arg name="my_rviz" value="-d $(find cartesian_controller_examples)/etc/examples.rviz" />
+                <node name="rviz" pkg="rviz" type="rviz" respawn="false" args="$(arg my_rviz)" output="screen" />
+        </group>
 </launch>

--- a/cartesian_controller_examples/launch/examples.launch
+++ b/cartesian_controller_examples/launch/examples.launch
@@ -7,7 +7,7 @@
 
         <!-- Load robot_description to parameter server -->
         <param name="/robot_description"
-        command="$(find xacro)/xacro --inorder '$(find cartesian_controller_examples)/urdf/robot.urdf.xacro'" />
+        command="$(find xacro)/xacro '$(find cartesian_controller_examples)/urdf/robot.urdf.xacro'" />
 
         <!-- Load hardware configuration -->
         <rosparam file="$(find cartesian_controller_examples)/config/example_hw_config.yaml" command="load"></rosparam>

--- a/cartesian_controller_examples/package.xml
+++ b/cartesian_controller_examples/package.xml
@@ -38,6 +38,7 @@
   <run_depend>xacro</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
+  <run_depend>joint_state_controller</run_depend>
   <run_depend>ros_control_boilerplate</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>robot_state_publisher</run_depend>

--- a/cartesian_controller_examples/package.xml
+++ b/cartesian_controller_examples/package.xml
@@ -35,7 +35,12 @@
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
+  <run_depend>xacro</run_depend>
+  <run_depend>rviz</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
+  <run_depend>ros_control_boilerplate</run_depend>
+  <run_depend>controller_manager</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
 
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->

--- a/cartesian_controller_tests/CMakeLists.txt
+++ b/cartesian_controller_tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(cartesian_controller_tests)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES cartesian_controller_tests
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+
+  add_rostest(cartesian_controllers.test)
+endif()

--- a/cartesian_controller_tests/README.md
+++ b/cartesian_controller_tests/README.md
@@ -1,0 +1,10 @@
+# Cartesian Controller Tests
+Integration tests and high-level concept validation for the *cartesian_controllers*.
+Unit tests are located in each package's `test` sub-folder.
+
+## Run tests manually
+In a sourced terminal, call
+```bash
+catkin_make run_tests_cartesian_controller_tests
+```
+to run the integration tests manually.

--- a/cartesian_controller_tests/cartesian_controllers.test
+++ b/cartesian_controller_tests/cartesian_controllers.test
@@ -1,0 +1,7 @@
+<launch>
+        <!--<include file="$(find cartesian_controller_examples)/launch/examples.launch"/>-->
+
+        <!-- Tests -->
+        <test test-name="test_startup" pkg="cartesian_controller_tests" type="test_startup.py" time-limit="60.0"/>
+
+</launch>

--- a/cartesian_controller_tests/cartesian_controllers.test
+++ b/cartesian_controller_tests/cartesian_controllers.test
@@ -1,5 +1,7 @@
 <launch>
-        <!--<include file="$(find cartesian_controller_examples)/launch/examples.launch"/>-->
+        <include file="$(find cartesian_controller_examples)/launch/examples.launch">
+                <arg name="rviz" value="false" />
+        </include>
 
         <!-- Tests -->
         <test test-name="test_startup" pkg="cartesian_controller_tests" type="test_startup.py" time-limit="60.0"/>

--- a/cartesian_controller_tests/integration_tests/test_startup.py
+++ b/cartesian_controller_tests/integration_tests/test_startup.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import sys
+import unittest
+import time
+import rospy
+
+PKG = 'cartesian_controller_tests'
+NAME = 'test_startup'
+
+
+class IntegrationTest(unittest.TestCase):
+    def __init__(self, *args):
+        super(IntegrationTest, self).__init__(*args)
+
+        rospy.init_node(NAME)
+
+    def test_controller_initialization(self):
+        """ Test whether every controller got initialized correctly """
+        self.assertEqual(True, True)
+
+if __name__ == '__main__':
+    import rostest
+    rostest.run(PKG, NAME, IntegrationTest, sys.argv)

--- a/cartesian_controller_tests/integration_tests/test_startup.py
+++ b/cartesian_controller_tests/integration_tests/test_startup.py
@@ -4,24 +4,46 @@ import unittest
 import time
 import rospy
 from controller_manager_msgs.srv import ListControllers
+from controller_manager_msgs.srv import SwitchController, SwitchControllerRequest
 
 PKG = 'cartesian_controller_tests'
 NAME = 'test_startup'
 
 
 class IntegrationTest(unittest.TestCase):
+    """ An integration test for controller initialization and startup
+
+    We check if each controller successfully performs the life cycle of:
+    `init()` - `starting()` - `update()` - `stopping()`.
+    """
     def __init__(self, *args):
         super(IntegrationTest, self).__init__(*args)
 
+        # Configuration
         rospy.init_node(NAME)
-
         timeout = rospy.Duration(5)
+        self.our_controllers = [
+            'my_cartesian_motion_controller',
+            'my_cartesian_force_controller',
+            'my_cartesian_compliance_controller',
+            'my_motion_control_handle',
+        ]
 
+        # ROS Interfaces
         self.list_controllers = rospy.ServiceProxy('/controller_manager/list_controllers', ListControllers)
         try:
             self.list_controllers.wait_for_service(timeout.to_sec())
         except rospy.exceptions.ROSException as err:
             self.fail("Service list_controllers not available: {}".format(err))
+
+        self.switch_controller = rospy.ServiceProxy('/controller_manager/switch_controller', SwitchController)
+        try:
+            self.switch_controller.wait_for_service(timeout.to_sec())
+        except rospy.exceptions.ROSException as err:
+            self.fail("Service switch_controllers not available: {}".format(err))
+
+        # Wait until controller spawner is done
+        time.sleep(3)
 
     def test_controller_initialization(self):
         """ Test whether every controller got initialized correctly
@@ -30,22 +52,48 @@ class IntegrationTest(unittest.TestCase):
         controller manager contains our controllers and if they have `state:
         initialized`.
         """
-        our_controllers = {
-            'my_cartesian_motion_controller': False,
-            'my_cartesian_force_controller': False,
-            'my_cartesian_compliance_controller': False,
-            'my_motion_control_handle': False,
-        }
-        time.sleep(3)  # Wait until controller spawner is done
+        for name in self.our_controllers:
+            self.assertTrue(self.check_state(name, 'initialized'), "{} is initialized correctly".format(name))
+
+    def test_controller_switches(self):
+        """ Test whether every controller starts, runs, and stops correctly
+
+        We start each of our controllers individually and check if its state is
+        `running`.  We then switch it off and check whether its state is
+        `stopped`.
+        """
+        for name in self.our_controllers:
+            self.start_controller(name)
+            self.assertTrue(self.check_state(name, 'running'), "{} is starting correctly".format(name))
+            time.sleep(1) # process some update() cycles
+            self.stop_controller(name)
+            self.assertTrue(self.check_state(name, 'stopped'), "{} is stopping correctly".format(name))
+
+    def check_state(self, controller, state):
+        """ Check the controller's state
+
+        Return True if the controller's state is `state`, else False.
+        Return False if the controller is not listed.
+        """
         listed_controllers = self.list_controllers()
-        for name in our_controllers.keys():
-            for entry in listed_controllers.controller:
-                if entry.name == name:
-                    our_controllers[name] = True if entry.state == 'initialized' else False
+        for entry in listed_controllers.controller:
+            if entry.name == controller:
+                return True if entry.state == state else False
+        return False
 
-        for key, value in our_controllers.items():
-            self.assertTrue(value, "{} initialized".format(key))
+    def start_controller(self, controller):
+        """ Start the given controller with a best-effort strategy """
+        srv = SwitchControllerRequest()
+        srv.start_controllers = [controller]
+        srv.strictness = SwitchControllerRequest.BEST_EFFORT
+        self.switch_controller(srv)
 
+    def stop_controller(self, controller):
+        """ Stop the given controller with a best-effort strategy """
+        srv = SwitchControllerRequest()
+        srv.stop_controllers = [controller]
+        srv.strictness = SwitchControllerRequest.BEST_EFFORT
+        self.switch_controller(srv)
 
 if __name__ == '__main__':
     import rostest

--- a/cartesian_controller_tests/integration_tests/test_startup.py
+++ b/cartesian_controller_tests/integration_tests/test_startup.py
@@ -36,6 +36,7 @@ class IntegrationTest(unittest.TestCase):
             'my_cartesian_compliance_controller': False,
             'my_motion_control_handle': False,
         }
+        time.sleep(3)  # Wait until controller spawner is done
         listed_controllers = self.list_controllers()
         for name in our_controllers.keys():
             for entry in listed_controllers.controller:

--- a/cartesian_controller_tests/integration_tests/test_startup.py
+++ b/cartesian_controller_tests/integration_tests/test_startup.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 import time
 import rospy
+from controller_manager_msgs.srv import ListControllers
 
 PKG = 'cartesian_controller_tests'
 NAME = 'test_startup'
@@ -14,9 +15,36 @@ class IntegrationTest(unittest.TestCase):
 
         rospy.init_node(NAME)
 
+        timeout = rospy.Duration(5)
+
+        self.list_controllers = rospy.ServiceProxy('/controller_manager/list_controllers', ListControllers)
+        try:
+            self.list_controllers.wait_for_service(timeout.to_sec())
+        except rospy.exceptions.ROSException as err:
+            self.fail("Service list_controllers not available: {}".format(err))
+
     def test_controller_initialization(self):
-        """ Test whether every controller got initialized correctly """
-        self.assertEqual(True, True)
+        """ Test whether every controller got initialized correctly
+
+        We check if the list of all controllers currently managed by the
+        controller manager contains our controllers and if they have `state:
+        initialized`.
+        """
+        our_controllers = {
+            'my_cartesian_motion_controller': False,
+            'my_cartesian_force_controller': False,
+            'my_cartesian_compliance_controller': False,
+            'my_motion_control_handle': False,
+        }
+        listed_controllers = self.list_controllers()
+        for name in our_controllers.keys():
+            for entry in listed_controllers.controller:
+                if entry.name == name:
+                    our_controllers[name] = True if entry.state == 'initialized' else False
+
+        for key, value in our_controllers.items():
+            self.assertTrue(value, "{} initialized".format(key))
+
 
 if __name__ == '__main__':
     import rostest

--- a/cartesian_controller_tests/package.xml
+++ b/cartesian_controller_tests/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>cartesian_controller_tests</name>
+  <version>0.0.0</version>
+  <description>Integration tests for the Cartesian controllers</description>
+
+  <maintainer email="scherzin@fzi.de">scherzin</maintainer>
+  <license>BSD</license>
+  <author email="scherzin@fzi.de">Stefan Scherzinger</author> 
+
+  <!-- Use test_depend for packages you need only for testing: -->
+  <test_depend>rostest</test_depend>
+  <test_depend>rospy</test_depend> 
+  <test_depend>cartesian_force_controller</test_depend> 
+  <test_depend>cartesian_motion_controller</test_depend> 
+  <test_depend>cartesian_compliance_controller</test_depend> 
+  <test_depend>cartesian_controller_handles</test_depend> 
+  <test_depend>cartesian_controller_examples</test_depend> 
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>


### PR DESCRIPTION
## Goal
Provide basic integration tests for the *cartesian_controllers*. We test whether the controllers correctly perform the normal life cycle of initialization, starting and stopping.


## Steps
- [x] Add general setup
- [x] Adjust the `examples.launch` (remaps, RViz optional, etc.)
- [x]  Test controller initialization
- [x]  Test controller starting