### PR TITLE
Improve compatibility of `CartesianComplianceController` with Moveit

### DIFF
--- a/joint_to_cartesian_controller/include/joint_to_cartesian_controller/JointControllerAdapter.h
+++ b/joint_to_cartesian_controller/include/joint_to_cartesian_controller/JointControllerAdapter.h
@@ -66,11 +66,10 @@ class JointControllerAdapter : public hardware_interface::RobotHW
 {
   public:
 
-    JointControllerAdapter();
+    JointControllerAdapter(std::vector<hardware_interface::JointStateHandle>& handles, ros::NodeHandle& nh);
     ~JointControllerAdapter();
 
-    bool init(const std::vector<hardware_interface::JointStateHandle>& handles, ros::NodeHandle& nh);
-
+    void read();
     void write(KDL::JntArray& positions);
 
   private:
@@ -85,7 +84,8 @@ class JointControllerAdapter : public hardware_interface::RobotHW
 
     joint_limits_interface::PositionJointSoftLimitsInterface m_limits_interface;
 
-    std::vector<hardware_interface::JointHandle>                        m_joint_handles;
+    std::vector<hardware_interface::JointStateHandle>&                  m_joint_state_handles;
+    std::vector<hardware_interface::JointHandle>                        m_joint_cmd_handles;
     std::vector<joint_limits_interface::PositionJointSoftLimitsHandle>  m_limits_handles;
 
     std::vector<double> m_cmd;

--- a/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
+++ b/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
@@ -55,6 +55,9 @@
 #include <kdl/chain.hpp>
 #include <kdl/chainfksolverpos_recursive.hpp>
 
+#include <memory>
+#include <thread>
+
 namespace joint_to_cartesian_controller
 {
 
@@ -98,11 +101,14 @@ class JointToCartesianController
     std::vector<std::string>   m_joint_names;
     ros::Publisher             m_pose_publisher;
 
-    JointControllerAdapter     m_controller_adapter;
+    std::unique_ptr<JointControllerAdapter> m_controller_adapter;
+    std::thread m_adapter_thread;
+    std::mutex m_mutex;
+
 
     KDL::Chain m_robot_chain;
     std::vector<
-      hardware_interface::JointStateHandle>   m_joint_handles;
+      hardware_interface::JointStateHandle>   m_joint_state_handles;
 
     std::shared_ptr<
       KDL::ChainFkSolverPos_recursive>        m_fk_solver;

--- a/joint_to_cartesian_controller/src/JointControllerAdapter.cpp
+++ b/joint_to_cartesian_controller/src/JointControllerAdapter.cpp
@@ -49,15 +49,12 @@
 namespace joint_to_cartesian_controller
 {
 
-JointControllerAdapter::JointControllerAdapter()
+JointControllerAdapter::JointControllerAdapter(std::vector<hardware_interface::JointStateHandle>& state_handles, ros::NodeHandle& nh)
+  : m_joint_state_handles(state_handles)
 {
-}
-
-bool JointControllerAdapter::init(const std::vector<hardware_interface::JointStateHandle>& state_handles, ros::NodeHandle& nh)
-{
-  for (size_t i = 0; i < state_handles.size(); ++i)
+  for (size_t i = 0; i < m_joint_state_handles.size(); ++i)
   {
-    m_joint_names.push_back(state_handles[i].getName());
+    m_joint_names.push_back(m_joint_state_handles[i].getName());
   }
   m_number_joints = m_joint_names.size();
   m_cmd.resize(m_number_joints);
@@ -71,19 +68,19 @@ bool JointControllerAdapter::init(const std::vector<hardware_interface::JointSta
   // Register external state_handles
   for (size_t i = 0; i < m_number_joints; ++i)
   {
-    m_state_interface.registerHandle(state_handles[i]);
+    m_state_interface.registerHandle(m_joint_state_handles[i]);
   }
   registerInterface(&m_state_interface);
 
   // Initialize and register handles to the actuators
   for (size_t i = 0; i < m_number_joints; ++i)
   {
-    m_joint_handles.push_back(
+    m_joint_cmd_handles.push_back(
         hardware_interface::JointHandle(
           m_state_interface.getHandle(m_joint_names[i]),
           &m_cmd[i]));
 
-    m_pos_interface.registerHandle(m_joint_handles[i]);
+    m_pos_interface.registerHandle(m_joint_cmd_handles[i]);
   }
   registerInterface(&m_pos_interface);
 
@@ -104,7 +101,7 @@ bool JointControllerAdapter::init(const std::vector<hardware_interface::JointSta
   {
     m_limits_handles.push_back(
         joint_limits_interface::PositionJointSoftLimitsHandle(
-          m_joint_handles[i],
+          m_joint_cmd_handles[i],
           limits,
           soft_limits // deliberately empty
           ));
@@ -114,23 +111,25 @@ bool JointControllerAdapter::init(const std::vector<hardware_interface::JointSta
   {
     m_limits_interface.registerHandle(m_limits_handles[i]);
   }
-
-  return true;
 }
 
 JointControllerAdapter::~JointControllerAdapter()
 {
 }
 
+void JointControllerAdapter::read()
+{
+  // Safe default comands
+  for (size_t i = 0; i < m_number_joints; ++i)
+  {
+    m_cmd[i] = m_joint_state_handles[i].getPosition();
+  }
+}
+
 void JointControllerAdapter::write(KDL::JntArray& positions)
 {
-  if (static_cast<size_t>(positions.data.size()) != m_cmd.size())
-  {
-    throw std::runtime_error("Joint number mismatch!");
-  }
-
   // Fill positions for forward kinematics
-  for (size_t i = 0; i < m_cmd.size(); ++i)
+  for (size_t i = 0; i < m_number_joints; ++i)
   {
     positions(i) = m_cmd[i];
   }

--- a/joint_to_cartesian_controller/src/joint_to_cartesian_controller.cpp
+++ b/joint_to_cartesian_controller/src/joint_to_cartesian_controller.cpp
@@ -156,7 +156,11 @@ bool JointToCartesianController::init(hardware_interface::JointStateInterface* h
   m_controller_adapter = std::make_unique<JointControllerAdapter>(m_joint_state_handles,nh);
   m_controller_manager.reset(new controller_manager::ControllerManager(m_controller_adapter.get(), nh));
 
-  // Process adapter callbacks even when we are not running
+  // Process adapter callbacks even when we are not running.
+  // This allows to interact with the adapter's controller manager without
+  // freezes.  We use an idealized update rate since we republish joint
+  // commands as Cartesian targets. The cartesian_controllers will interpolate
+  // these targets for the robot driver's real control rate.
   m_adapter_thread = std::thread([this] {
     constexpr int frequency = 100;
     auto rate               = ros::Rate(frequency);


### PR DESCRIPTION
## Goal
Users can plan robot end-effector motion with Moveit and execute that with Cartesian compliance in contact.

## Approach
Moveit's output is a `FollowJointTrajectoryGoal` that best integrates with the `joint_trajectory_controller`. The *cartesian_controllers* repository already provides a `JointControllerAdapter` that allows to connect such a `joint_trajectory_controller` and turn the joint-based trajectory into Cartesian targets via robot forward kinematics. For motion that is sufficiently away from robot singularities, this could provide a suitable approach combine motion planning with compliance.

## Steps
- [x] Test the `joint_to_cartesian_controller` package with rqt
- [x] Fix the dangling robot chain
- [x] Fix possible controller freezes. I remember that one could create a deadlock with the controller's internal controller manager


---
Resolves #18 , resolves #28 