### PR TITLE
update robot.urdf.xacro urdf like mentioned at issue #32

### DIFF
--- a/cartesian_controller_examples/urdf/robot.urdf.xacro
+++ b/cartesian_controller_examples/urdf/robot.urdf.xacro
@@ -220,7 +220,7 @@
         </link>
 
         <joint name="tool0_joint" type="fixed">
-                <origin xyz="${link6_length / 2.0} 0 0" rpy="0 ${pi / 2.0} 0"/>
+                <origin xyz="0 0 ${link6_length / 2.0}" rpy="0 0 0"/>
                 <parent link="sensor_link"/>
                 <child link="tool0"/>
         </joint>
@@ -237,7 +237,7 @@
 
         <!-- Attach a sensor link -->
         <joint name="sensor_link_joint" type="fixed">
-                <origin xyz="0 ${link6_length / 2.0} 0" rpy="${-pi / 2.0} 0 ${pi / 2.0}"/>
+                <origin xyz="0 ${link6_length / 2.0} 0" rpy="${-pi / 2.0} 0 0"/>
                 <parent link="link6"/>
                 <child link="sensor_link"/>
         </joint>

--- a/cartesian_controller_examples/urdf/robot.urdf.xacro
+++ b/cartesian_controller_examples/urdf/robot.urdf.xacro
@@ -220,8 +220,8 @@
         </link>
 
         <joint name="tool0_joint" type="fixed">
-                <origin xyz="0 ${link6_length} 0" rpy="${-pi / 2.0} 0 0"/>
-                <parent link="link6"/>
+                <origin xyz="${link6_length / 2.0} 0 0" rpy="0 ${pi / 2.0} 0"/>
+                <parent link="sensor_link"/>
                 <child link="tool0"/>
         </joint>
         <link name="tool0">


### PR DESCRIPTION
I think that latest version robot.urdf.xacro does not match to a policy of a kinematic chain mentioned at [Issue #32](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/issues/32). I hope this is helpful for maintainer here.

[view_frames from original robot.urdf.xacro](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/files/7885586/frames_original.pdf)

[view_frames from the updated ](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/files/7885587/frames_updated.pdf)
