### PR TITLE
Clean-up ROS2 state and command interfaces

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -45,6 +45,7 @@
 #include <cartesian_controller_base/Utility.h>
 
 // ros_controls
+#include <functional>
 #include <hardware_interface/loaned_state_interface.hpp>
 #include <hardware_interface/loaned_command_interface.hpp>
 
@@ -124,18 +125,23 @@ class IKSolver
     const KDL::JntArray& getPositions() const;
 
     //! Set initial joint configuration
-    bool setStartState(const std::vector<hardware_interface::LoanedStateInterface>& joint_handles);
+    bool setStartState(
+      const std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface> >&
+        joint_pos_handles);
 
     /**
      * @brief Synchronize joint positions with the real robot
      *
      * Call this periodically in the controller's update() function.
-     * The internal model's joint velocity is not sychronized. Derived IK
-     * solvers should implement how to keep or reset those values.
+     * The internal model's joint velocity is not sychronized. This makes the
+     * solver more stable. Derived IK solvers should implement how to keep or
+     * reset those values.
      *
-     * @param joint_handles Read handles to the joints.
+     * @param joint_pos_handles Read handles to the joint positions.
      */
-    void synchronizeJointPositions(const std::vector<hardware_interface::LoanedStateInterface>& joint_handles);
+    void synchronizeJointPositions(
+      const std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface> >&
+        joint_pos_handles);
 
     /**
      * @brief Initialize the solver

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -176,7 +176,10 @@ class CartesianControllerBase : public controller_interface::ControllerInterface
       m_joint_state_pos_handles;
 
   private:
-    std::vector<hardware_interface::LoanedCommandInterface>   m_joint_cmd_handles;
+    std::vector<std::string> m_cmd_interface_types;
+    std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>> m_joint_cmd_pos_handles;
+    std::vector<std::reference_wrapper<hardware_interface::LoanedCommandInterface>> m_joint_cmd_vel_handles;
+
     std::vector<std::string>                          m_joint_names;
     trajectory_msgs::msg::JointTrajectoryPoint        m_simulated_joint_motion;
     SpatialPDController                               m_spatial_controller;

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -41,6 +41,7 @@
 #define CARTESIAN_CONTROLLER_BASE_H_INCLUDED
 
 // ROS
+#include <functional>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <trajectory_msgs/msg/joint_trajectory_point.hpp>
@@ -171,7 +172,8 @@ class CartesianControllerBase : public controller_interface::ControllerInterface
     std::string m_robot_base_link;
     int m_iterations;
 
-    std::vector<hardware_interface::LoanedStateInterface>     m_joint_state_handles;
+    std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface> >
+      m_joint_state_pos_handles;
 
   private:
     std::vector<hardware_interface::LoanedCommandInterface>   m_joint_cmd_handles;

--- a/cartesian_controller_base/src/IKSolver.cpp
+++ b/cartesian_controller_base/src/IKSolver.cpp
@@ -42,6 +42,7 @@
 #include <cartesian_controller_base/IKSolver.h>
 
 // other
+#include <functional>
 #include <map>
 #include <sstream>
 #include <algorithm>
@@ -79,35 +80,42 @@ namespace cartesian_controller_base{
 
 
   bool IKSolver::setStartState(
-      const std::vector<hardware_interface::LoanedStateInterface>& joint_state_handles)
+    const std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface> >&
+      joint_pos_handles)
   {
     // Copy into internal buffers.
-    for (int i = 0; i < joint_state_handles.size(); ++i)
+    for (int i = 0; i < joint_pos_handles.size(); ++i)
     {
-      if (joint_state_handles[i].get_interface_name() == hardware_interface::HW_IF_POSITION)
+      // Interface type should be checked by the caller.
+      // Add additional plausibility check just in case.
+      if (joint_pos_handles[i].get().get_interface_name() == hardware_interface::HW_IF_POSITION)
       {
-        m_current_positions(i)      = joint_state_handles[i].get_value();
-        m_current_velocities(i)     = 0.0;
-        m_current_accelerations(i)  = 0.0;
-        m_last_positions(i)         = m_current_positions(i);
-        m_last_velocities(i)        = m_current_velocities(i);
+        m_current_positions(i)     = joint_pos_handles[i].get().get_value();
+        m_current_velocities(i)    = 0.0;
+        m_current_accelerations(i) = 0.0;
+        m_last_positions(i)        = m_current_positions(i);
+        m_last_velocities(i)       = m_current_velocities(i);
       }
-      else return false;
+      else
+      {
+        return false;
+      }
     }
     return true;
   }
 
 
   void IKSolver::synchronizeJointPositions(
-    const std::vector<hardware_interface::LoanedStateInterface>& joint_state_handles)
+    const std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface> >&
+      joint_pos_handles)
   {
-    for (size_t i = 0; i < joint_state_handles.size(); ++i)
+    for (size_t i = 0; i < joint_pos_handles.size(); ++i)
     {
-      // TODO: We need both joint positions and velocities.
-      // Get both from the system_interface.
-      if (joint_state_handles[i].get_interface_name() == hardware_interface::HW_IF_POSITION)
+      // Interface type should be checked by the caller.
+      // Add additional plausibility check just in case.
+      if (joint_pos_handles[i].get().get_interface_name() == hardware_interface::HW_IF_POSITION)
       {
-        m_current_positions(i) = joint_state_handles[i].get_value();
+        m_current_positions(i) = joint_pos_handles[i].get().get_value();
         m_last_positions(i)    = m_current_positions(i);
       }
     }

--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -67,10 +67,13 @@ controller_interface::InterfaceConfiguration CartesianControllerBase::command_in
 {
   controller_interface::InterfaceConfiguration conf;
   conf.type = controller_interface::interface_configuration_type::INDIVIDUAL;
-  conf.names.reserve(m_joint_names.size() * 1); // only position for now
-  for (const auto & joint_name : m_joint_names)
+  conf.names.reserve(m_joint_names.size() * m_cmd_interface_types.size());
+  for (const auto& type : m_cmd_interface_types)
   {
-    conf.names.push_back(joint_name + "/position");
+    for (const auto & joint_name : m_joint_names)
+    {
+      conf.names.push_back(joint_name + std::string("/").append(type));
+    }
   }
   return conf;
 }
@@ -100,6 +103,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
   auto_declare<std::string>("robot_base_link", "");
   auto_declare<std::string>("end_effector_link", "");
   auto_declare<std::vector<std::string>>("joints", std::vector<std::string>());
+  auto_declare<std::vector<std::string>>("command_interfaces", std::vector<std::string>());
   auto_declare<double>("solver.error_scale", 1.0);
   auto_declare<int>("solver.iterations", 1);
 
@@ -126,6 +130,7 @@ controller_interface::return_type CartesianControllerBase::init(const std::strin
   auto_declare<std::string>("robot_base_link", "");
   auto_declare<std::string>("end_effector_link", "");
   auto_declare<std::vector<std::string>>("joints", std::vector<std::string>());
+  auto_declare<std::vector<std::string>>("command_interfaces", std::vector<std::string>());
   auto_declare<double>("solver.error_scale", 1.0);
   auto_declare<int>("solver.iterations", 1);
 
@@ -236,6 +241,26 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
   // Initialize Cartesian pd controllers
   m_spatial_controller.init(get_node());
 
+  // Check command interfaces.
+  // We support position, velocity, or both.
+  m_cmd_interface_types = get_node()->get_parameter("command_interfaces").as_string_array();
+  if (m_cmd_interface_types.empty())
+  {
+    RCLCPP_ERROR(get_node()->get_logger(), "No command_interfaces specified");
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  for (const auto& type : m_cmd_interface_types)
+  {
+    if (type != hardware_interface::HW_IF_POSITION && type != hardware_interface::HW_IF_VELOCITY)
+    {
+      RCLCPP_ERROR(
+        get_node()->get_logger(),
+        "Unsupported command interface: %s. Choose position or velocity",
+        type.c_str());
+      return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+    }
+  }
+
   m_already_initialized = true;
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
@@ -250,6 +275,26 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn CartesianControllerBase::on_activate(
     const rclcpp_lifecycle::State & previous_state)
 {
+  // Get command handles.
+  for (const auto& type : m_cmd_interface_types)
+  {
+    if (!controller_interface::get_ordered_interfaces(command_interfaces_,
+                                                      m_joint_names,
+                                                      type,
+                                                      (type == hardware_interface::HW_IF_POSITION)
+                                                        ? m_joint_cmd_pos_handles
+                                                        : m_joint_cmd_vel_handles))
+    {
+      RCLCPP_ERROR(node_->get_logger(),
+                   "Expected %zu '%s' state interfaces, got %zu.",
+                   m_joint_names.size(),
+                   type.c_str(),
+                   m_joint_state_pos_handles.size());
+      return CallbackReturn::ERROR;
+    }
+  }
+
+  // Get state handles.
   if (!controller_interface::get_ordered_interfaces(state_interfaces_,
                                                     m_joint_names,
                                                     hardware_interface::HW_IF_POSITION,
@@ -275,10 +320,23 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
 
 void CartesianControllerBase::writeJointControlCmds()
 {
-  // Only position commands for now
-  for (size_t i = 0; i < m_joint_names.size(); ++i)
+  // Write all available types.
+  for (const auto& type : m_cmd_interface_types)
   {
-    command_interfaces_[i].set_value(m_simulated_joint_motion.positions[i]);
+    if (type == hardware_interface::HW_IF_POSITION)
+    {
+      for (size_t i = 0; i < m_joint_names.size(); ++i)
+      {
+        m_joint_cmd_pos_handles[i].get().set_value(m_simulated_joint_motion.positions[i]);
+      }
+    }
+    if (type == hardware_interface::HW_IF_VELOCITY)
+    {
+      for (size_t i = 0; i < m_joint_names.size(); ++i)
+      {
+        m_joint_cmd_vel_handles[i].get().set_value(m_simulated_joint_motion.velocities[i]);
+      }
+    }
   }
 }
 

--- a/cartesian_force_controller/src/cartesian_force_controller.cpp
+++ b/cartesian_force_controller/src/cartesian_force_controller.cpp
@@ -127,7 +127,7 @@ controller_interface::return_type CartesianForceController::update()
 #endif
 {
   // Synchronize the internal model and the real robot
-  Base::m_ik_solver->synchronizeJointPositions(Base::m_joint_state_handles);
+  Base::m_ik_solver->synchronizeJointPositions(Base::m_joint_state_pos_handles);
 
   // Control the robot motion in such a way that the resulting net force
   // vanishes.  The internal 'simulation time' is deliberately independent of


### PR DESCRIPTION
## Goal
- [x] Require a `position` state interface for each joint
- [x] Allow to choose `position` , `velocity`, or *both* as command interfaces. The `system_interfaces` of the robots then decide what makes sense for their drivers.