### PR TITLE
Revert "Limit max. tolerated motion offsets per control cycle"

### DIFF
--- a/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.hpp
+++ b/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.hpp
@@ -155,8 +155,11 @@ computeMotionError()
 
   // Clamp maximal tolerated error.
   // The remaining error will be handled in the next control cycle.
-  const double max_angle = 0.1;
-  const double max_distance = 0.01;
+  // Note that this is also the maximal offset that the
+  // cartesian_compliance_controller can use to build up a restoring stiffness
+  // wrench.
+  const double max_angle = 1.0;
+  const double max_distance = 1.0;
   angle    = std::clamp(angle,-max_angle,max_angle);
   distance = std::clamp(distance,-max_distance,max_distance);
 


### PR DESCRIPTION
This reverts commit 24f1a9cc1046c3ac4254d6ccdf1f91864ee37d39.

As it turns out, limiting the max. tolerated motion offset also limits
the maximal stiffness that the `cartesian_compliance_controller` can
build up. The restoring compliance force is computed with the motion
error and the stiffness. If the motion error is limited, so is the
stiffness, rendering the compliance behavior useless.

We are now back to the previous behavior.