### PR TITLE
Accept ft sensor when not part of the robot kinematic chain

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -144,6 +144,8 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      */
     ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
 
+    KDL::Tree m_robot_tree;
+    KDL::Chain m_robot_chain;
     std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
 
     /**

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -90,8 +90,6 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
 
   std::string robot_description;
   urdf::Model robot_model;
-  KDL::Tree   robot_tree;
-  KDL::Chain  robot_chain;
 
   // Get controller specific configuration
   if (!ros::param::search("robot_description", robot_description))
@@ -121,14 +119,14 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     ROS_ERROR("Failed to parse urdf model from 'robot_description'");
     return false;
   }
-  if (!kdl_parser::treeFromUrdfModel(robot_model,robot_tree))
+  if (!kdl_parser::treeFromUrdfModel(robot_model,m_robot_tree))
   {
     const std::string error = ""
       "Failed to parse KDL tree from urdf model";
     ROS_ERROR_STREAM(error);
     throw std::runtime_error(error);
   }
-  if (!robot_tree.getChain(m_robot_base_link,m_end_effector_link,robot_chain))
+  if (!m_robot_tree.getChain(m_robot_base_link,m_end_effector_link,m_robot_chain))
   {
     const std::string error = ""
       "Failed to parse robot chain from urdf model. "
@@ -178,9 +176,9 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Initialize solvers
-  m_ik_solver->init(nh, robot_chain,upper_pos_limits,lower_pos_limits);
+  m_ik_solver->init(nh, m_robot_chain,upper_pos_limits,lower_pos_limits);
   KDL::Tree tmp("not_relevant");
-  tmp.addChain(robot_chain,"not_relevant");
+  tmp.addChain(m_robot_chain,"not_relevant");
   m_forward_kinematics_solver.reset(new KDL::TreeFkSolverPos_recursive(tmp));
 
   // Initialize Cartesian pd controllers

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -107,6 +107,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     ctrl::Vector6D        compensateGravity();
 
     void targetWrenchCallback(const geometry_msgs::WrenchStamped& wrench);
+    void addSensorChainToRobotFK();
     void ftSensorWrenchCallback(const geometry_msgs::WrenchStamped& wrench);
     bool signalTaringCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res);
 


### PR DESCRIPTION
Drop the URDF requirement for having the ft sensor in the robot kinematic chain. Some URDF robots have their ft sensor reference frame not in the end effector chain. User's don't have too modify their URDF with this PR. Working on a real UR3 robot with dual gripper.

As I'm writing this, maybe adding the ft reference frame in a new URDF kinematic chain is bad practice... The more I think about this the more I better like the original URDF requirement to have the ft sensor in same kinematic robot chain.

Fixes #32.