### PR TITLE
Warn user that all links must be part of the same kinematic chain

### DIFF
--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
@@ -76,19 +76,11 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Make sure compliance link is part of the robot chain
-  bool compliance_link_found = false;
-  for(std::vector<KDL::Segment>::reverse_iterator robot_segment = Base::m_robot_chain.segments.rbegin();
-      robot_segment != Base::m_robot_chain.segments.rend(); ++robot_segment)
+  if(!Base::robotChainContains(m_compliance_ref_link))
   {
-    if(robot_segment->getName().compare(m_compliance_ref_link) == 0){
-      compliance_link_found = true;
-      break;
-    }
-  }
-
-  if(!compliance_link_found)
-  {
-    ROS_ERROR_STREAM("The 'compliance_ref_link' MUST be part of the same robot kinematic chain");
+    ROS_ERROR_STREAM(m_compliance_ref_link << " is not part of the kinematic chain from "
+                                           << Base::m_robot_base_link << " to "
+                                           << Base::m_end_effector_link);
     return false;
   }
 

--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
@@ -75,6 +75,23 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     return false;
   }
 
+  // Make sure compliance link is part of the robot chain
+  bool compliance_link_found = false;
+  for(std::vector<KDL::Segment>::reverse_iterator robot_segment = Base::m_robot_chain.segments.rbegin();
+      robot_segment != Base::m_robot_chain.segments.rend(); ++robot_segment)
+  {
+    if(robot_segment->getName().compare(m_compliance_ref_link) == 0){
+      compliance_link_found = true;
+      break;
+    }
+  }
+
+  if(!compliance_link_found)
+  {
+    ROS_ERROR_STREAM("The 'compliance_ref_link' MUST be part of the same robot kinematic chain");
+    return false;
+  }
+
   // Make sure sensor wrenches are interpreted correctly
   ForceBase::setFtSensorReferenceFrame(m_compliance_ref_link);
 

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -144,7 +144,27 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      */
     ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
 
+    /**
+     * @brief Check if specified links are part of the robot chain
+     *
+     * @param s Link to check for existence
+     *
+     * @return True if existent, false otherwise
+     */
+    bool robotChainContains(const std::string& s)
+    {
+      for (const auto& segment : this->m_robot_chain.segments)
+      {
+        if (segment.getName() == s)
+        {
+          return true;
+        }
+      }
+      return false;
+    }
+
     KDL::Chain m_robot_chain;
+
     std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
 
     /**

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -144,6 +144,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      */
     ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
 
+    KDL::Chain m_robot_chain;
     std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
 
     /**

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -91,7 +91,6 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   std::string robot_description;
   urdf::Model robot_model;
   KDL::Tree   robot_tree;
-  KDL::Chain  robot_chain;
 
   // Get controller specific configuration
   if (!ros::param::search("robot_description", robot_description))
@@ -128,7 +127,7 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     ROS_ERROR_STREAM(error);
     throw std::runtime_error(error);
   }
-  if (!robot_tree.getChain(m_robot_base_link,m_end_effector_link,robot_chain))
+  if (!robot_tree.getChain(m_robot_base_link,m_end_effector_link,m_robot_chain))
   {
     const std::string error = ""
       "Failed to parse robot chain from urdf model. "
@@ -178,9 +177,9 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Initialize solvers
-  m_ik_solver->init(nh, robot_chain,upper_pos_limits,lower_pos_limits);
+  m_ik_solver->init(nh, m_robot_chain,upper_pos_limits,lower_pos_limits);
   KDL::Tree tmp("not_relevant");
-  tmp.addChain(robot_chain,"not_relevant");
+  tmp.addChain(m_robot_chain,"not_relevant");
   m_forward_kinematics_solver.reset(new KDL::TreeFkSolverPos_recursive(tmp));
 
   // Initialize Cartesian pd controllers

--- a/cartesian_controller_examples/config/example_controllers.yaml
+++ b/cartesian_controller_examples/config/example_controllers.yaml
@@ -42,7 +42,7 @@ my_cartesian_force_controller:
 
 my_cartesian_compliance_controller:
     type: "position_controllers/CartesianComplianceController"
-    end_effector_link: "tool0"    # All links below must come before this link
+    end_effector_link: "tool0"
     robot_base_link: "base_link"
     ft_sensor_ref_link: "sensor_link"
     compliance_ref_link: "tool0"

--- a/cartesian_controller_examples/urdf/robot.urdf.xacro
+++ b/cartesian_controller_examples/urdf/robot.urdf.xacro
@@ -24,6 +24,14 @@
                 <color rgba="0.3 0.3 0.3 1.0"/>
         </material>
 
+        <!-- Connect to world -->
+        <link name="world" />
+        <joint name="world_joint" type="fixed">
+                <parent link="world" />
+                <child link = "base_link" />
+                <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+        </joint>
+
         <link name="base_link" >
                 <visual name="joint">
                         <origin xyz="0 0 ${joint_length / 2.0}" rpy="0 0 0" />
@@ -219,6 +227,15 @@
                 </visual>
         </link>
 
+        <!-- Attach a sensor link -->
+        <joint name="sensor_link_joint" type="fixed">
+                <origin xyz="0 ${link6_length / 2.0} 0" rpy="${-pi / 2.0} 0 0"/>
+                <parent link="link6"/>
+                <child link="sensor_link"/>
+        </joint>
+        <link name="sensor_link"/>
+
+        <!-- The default end-effector -->
         <joint name="tool0_joint" type="fixed">
                 <origin xyz="0 0 ${link6_length / 2.0}" rpy="0 0 0"/>
                 <parent link="sensor_link"/>
@@ -234,21 +251,19 @@
                 </visual>
         </link>
 
-
-        <!-- Attach a sensor link -->
-        <joint name="sensor_link_joint" type="fixed">
+        <!-- Additional links for integration tests. -->
+        <joint name="invalid_sensor_link_joint" type="fixed">
                 <origin xyz="0 ${link6_length / 2.0} 0" rpy="${-pi / 2.0} 0 0"/>
                 <parent link="link6"/>
-                <child link="sensor_link"/>
+                <child link="invalid_sensor_link"/>
         </joint>
-        <link name="sensor_link"/>
+        <link name="invalid_sensor_link"/>
 
-        <!-- Connect to world -->
-        <link name="world" />
-        <joint name="world_joint" type="fixed">
-                <parent link="world" />
-                <child link = "base_link" />
-                <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
+        <joint name="invalid_compliance_link_joint" type="fixed">
+                <origin xyz="0 0 0" rpy="0 0 0"/>
+                <parent link="sensor_link"/>
+                <child link="invalid_compliance_link"/>
         </joint>
+        <link name="invalid_compliance_link"/>
 
 </robot>

--- a/cartesian_controller_tests/cartesian_controllers.test
+++ b/cartesian_controller_tests/cartesian_controllers.test
@@ -3,6 +3,17 @@
                 <arg name="rviz" value="false" />
         </include>
 
+        <!-- Load additional controller configuration -->
+        <rosparam file="$(find cartesian_controller_tests)/config/invalid_controllers.yaml" command="load"></rosparam>
+
+        <!-- Spawn controllers -->
+        <node name="invalid_controller_spawner" pkg="controller_manager" type="spawner"
+                args="--stopped
+                invalid_cartesian_force_controller
+                invalid_cartesian_compliance_controller
+                "
+        />
+
         <!-- Tests -->
         <test test-name="test_startup" pkg="cartesian_controller_tests" type="test_startup.py" time-limit="60.0"/>
 

--- a/cartesian_controller_tests/config/invalid_controllers.yaml
+++ b/cartesian_controller_tests/config/invalid_controllers.yaml
@@ -1,0 +1,61 @@
+invalid_cartesian_force_controller:
+    type: "position_controllers/CartesianForceController"
+    end_effector_link: "tool0"
+    robot_base_link: "base_link"
+
+    # Invalid: The sensor link is not part of the kinematic chain from
+    # robot_base_link to end_effector_link
+    ft_sensor_ref_link: "invalid_sensor_link"
+
+    joints:
+    - joint1
+    - joint2
+    - joint3
+    - joint4
+    - joint5
+    - joint6
+
+    pd_gains: # arbitrary
+        trans_x: {p: 0.0}
+        trans_y: {p: 0.0}
+        trans_z: {p: 0.0}
+        rot_x: {p: 0.0}
+        rot_y: {p: 0.0}
+        rot_z: {p: 0.0}
+
+invalid_cartesian_compliance_controller:
+    type: "position_controllers/CartesianComplianceController"
+    end_effector_link: "tool0"
+    robot_base_link: "base_link"
+    ft_sensor_ref_link: "sensor_link"
+
+    # Invalid: the compliance link is not part of the kinematic chain from
+    # robot_base_link to end_effector_link
+    compliance_ref_link: "invalid_compliance_link"
+
+    joints:
+    - joint1
+    - joint2
+    - joint3
+    - joint4
+    - joint5
+    - joint6
+
+    # arbitrary
+    stiffness:
+        trans_x: 500
+        trans_y: 500
+        trans_z: 500
+        rot_x: 100
+        rot_y: 100
+        rot_z: 100
+
+    # arbitrary
+    pd_gains:
+        trans_x: {p: 0.0}
+        trans_y: {p: 0.0}
+        trans_z: {p: 0.0}
+        rot_x: {p: 0.0}
+        rot_y: {p: 0.0}
+        rot_z: {p: 0.0}
+

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -69,6 +69,23 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     return false;
   }
 
+  // Make sure sensor link is part of the robot chain
+  bool sensor_link_found = false;
+  for(std::vector<KDL::Segment>::reverse_iterator robot_segment = Base::m_robot_chain.segments.rbegin();
+      robot_segment != Base::m_robot_chain.segments.rend(); ++robot_segment)
+  {
+    if(robot_segment->getName().compare(m_ft_sensor_ref_link) == 0){
+      sensor_link_found = true;
+      break;
+    }
+  }
+
+  if(!sensor_link_found)
+  {
+    ROS_ERROR_STREAM("The 'ft_sensor_ref_link' MUST be part of the same robot kinematic chain");
+    return false;
+  }
+
   // Make sure sensor wrenches are interpreted correctly
   setFtSensorReferenceFrame(Base::m_end_effector_link);
 

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -70,19 +70,11 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Make sure sensor link is part of the robot chain
-  bool sensor_link_found = false;
-  for(std::vector<KDL::Segment>::reverse_iterator robot_segment = Base::m_robot_chain.segments.rbegin();
-      robot_segment != Base::m_robot_chain.segments.rend(); ++robot_segment)
+  if(!Base::robotChainContains(m_ft_sensor_ref_link))
   {
-    if(robot_segment->getName().compare(m_ft_sensor_ref_link) == 0){
-      sensor_link_found = true;
-      break;
-    }
-  }
-
-  if(!sensor_link_found)
-  {
-    ROS_ERROR_STREAM("The 'ft_sensor_ref_link' MUST be part of the same robot kinematic chain");
+    ROS_ERROR_STREAM(m_ft_sensor_ref_link << " is not part of the kinematic chain from "
+                                           << Base::m_robot_base_link << " to "
+                                           << Base::m_end_effector_link);
     return false;
   }
 


### PR DESCRIPTION
The force and compliance controller will fail to initialise when not part of the same kinematic chain. Will avoid pitfall of #32 for new users.