### PR TITLE
Fix possible jumps on the UR robots when we are the first controllers to start

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -210,6 +210,10 @@ starting(const ros::Time& time)
   // Copy joint state to internal simulation
   m_ik_solver->setStartState(m_joint_handles);
   m_ik_solver->updateKinematics();
+
+  // Provide safe command buffers with starting where we are
+  computeJointControlCmds(ctrl::Vector6D::Zero(), ros::Duration(0));
+  writeJointControlCmds();
 }
 
 template <>


### PR DESCRIPTION
## Problem

On the current UR ROS1 driver, the `cartesian_controllers` might introduce jumps when they are the first controllers to be loaded with the driver.
This happens because the cartesian_controllers' `update()` will only be called on the *second* cycle of the respective controller manager. On the *first* cycle, the controllers will only be started and the underlying robot drivers might write the still untouched command buffers to the actuators.

Depending on other robot drivers' implementations (especially on their command buffer initialization), this could happen as well and cause safety critical jumps.

Thanks to @KKSTB for pointing this out [here](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/issues/73#issuecomment-1236025074) and thanks to @captain-yoshi for confirming this use case [here](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/issues/73#issuecomment-1236229485).

## Approach

We provide safe default command buffers already on `starting()`.
For instance, the `joint_trajectory_controller` also does this in its [starting routine](https://github.com/ros-controls/ros_controllers/blob/noetic-devel/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L141).

## Steps
- [x] Apply the fix
- [x] Test this on a UR robot
- [x] Open an PR for the ROS2 version

