### PR TITLE
Add stability observed sensitivity

### DIFF
--- a/cartesian_controller_utilities/CMakeLists.txt
+++ b/cartesian_controller_utilities/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(spacenav_utils)
+project(cartesian_controller_utilities)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
@@ -104,7 +104,7 @@ find_package(catkin REQUIRED COMPONENTS
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
-#  LIBRARIES spacenav_utils
+#  LIBRARIES cartesian_controller_utitilies
 #  CATKIN_DEPENDS rospy
 #  DEPENDS system_lib
 )
@@ -122,7 +122,7 @@ include_directories(
 
 ## Declare a C++ library
 # add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/spacenav_utils.cpp
+#   src/${PROJECT_NAME}/cartesian_controller_utitilies.cpp
 # )
 
 ## Add cmake target dependencies of the library
@@ -133,7 +133,7 @@ include_directories(
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/spacenav_utils_node.cpp)
+# add_executable(${PROJECT_NAME}_node src/cartesian_controller_utilities_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -197,7 +197,7 @@ install(
 #############
 
 ## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_spacenav_utils.cpp)
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_cartesian_controller_utitilies.cpp)
 # if(TARGET ${PROJECT_NAME}-test)
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()

--- a/cartesian_controller_utilities/CMakeLists.txt
+++ b/cartesian_controller_utilities/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(spacenav_utils)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  geometry_msgs
+  sensor_msgs
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+## catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES spacenav_utils
+#  CATKIN_DEPENDS rospy
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/spacenav_utils.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/spacenav_utils_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+install(PROGRAMS
+  scripts/buttons.py
+  scripts/converter.py
+  scripts/pose.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark executables and/or libraries for installation
+# install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+install(
+  DIRECTORY etc launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#install(FILES
+#  # myfile1
+#  # myfile2
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_spacenav_utils.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/cartesian_controller_utilities/README.md
+++ b/cartesian_controller_utilities/README.md
@@ -1,0 +1,29 @@
+# Spacenav Utils
+A helper package to bring some additional functionality to the *spacenav_node* package.
+
+This package is meant to turn the *spacenav_node* from the *joystick_drivers* package into a force control input device.
+Re-publish *geometry_msgs/Twist* messages
+as *geometry_msgs/WrenchStamped* messages and define custom commands for the buttons.
+For example could you trigger the recording of rosbags with the spacenav buttons. Check the *etc/button_cmds.yaml*.
+
+Adjust the launch files as needed.
+
+## Usage
+```bash
+roslaunch spacenav_utils spacenav_to_wrench.launch
+roslaunch spacenav_utils buttons_events.launch
+```
+## Disable GUI control in Gazebo
+When working with the 3DConnexion as a force control input device, you probably don't want to control gazebo's camera at the same time. Remember your kernel drivers still treat your force control thing as a space mouse, which is used by gazebo by default. To switch this behavior off add the following lines to the *~/.gazebo/gui.ini* file:
+```
+[spacenav]
+deadband_x = 0.1
+deadband_y = 0.1
+deadband_z = 0.1
+deadband_rx = 0.1
+deadband_ry = 0.1
+deadband_rz = 0.1
+topic=~/spacenav/remapped_joy_topic_to_something_not_used
+```
+More information can be found here:
+  http://answers.gazebosim.org/question/14225/how-can-i-turn-off-the-space-navigators-control-of-the-camera/

--- a/cartesian_controller_utilities/README.md
+++ b/cartesian_controller_utilities/README.md
@@ -1,18 +1,27 @@
-# Spacenav Utils
-A helper package to bring some additional functionality to the *spacenav_node* package.
+# Cartesian Controller Utilities
+A helper package with additional functionality for the `spacenav_node`.
 
-This package is meant to turn the *spacenav_node* from the *joystick_drivers* package into a force control input device.
-Re-publish *geometry_msgs/Twist* messages
-as *geometry_msgs/WrenchStamped* messages and define custom commands for the buttons.
-For example could you trigger the recording of rosbags with the spacenav buttons. Check the *etc/button_cmds.yaml*.
+This package turns the *spacenav_node* from the
+[joystick_drivers](https://github.com/ros-drivers/joystick_drivers) into a
+force and motion control input device for teleoperation with the `cartesian_controllers`:
 
-Adjust the launch files as needed.
+- **Force control**: Re-publish `geometry_msgs/Twist` messages as `geometry_msgs/WrenchStamped` messages to intuitively control the `target_wrench`.
+- **Motion control**: Turn `geometry_msgs/Twist` messages into a `geometry_msgs/PoseStamped` to smoothly steer the robot via its `target_frame`.
+- **Button commands**: Define custom commands for the spacenav buttons with ROS command line instructions. You can trigger events, such as calling ROS services and publish to topics.
 
 ## Usage
+Load the spacenav device with
 ```bash
-roslaunch spacenav_utils spacenav_to_wrench.launch
-roslaunch spacenav_utils buttons_events.launch
+roslaunch cartesian_controller_utilities spacenav.launch
 ```
+Depending on your use case, call one (or several) of these:
+```bash
+roslaunch cartesian_controller_utilities spacenav_to_wrench.launch
+roslaunch cartesian_controller_utilities spacenav_to_pose.launch
+roslaunch cartesian_controller_utilities buttons_events.launch
+```
+Also check the configuration parameters in each `.launch` file.
+
 ## Disable GUI control in Gazebo
 When working with the 3DConnexion as a force control input device, you probably don't want to control gazebo's camera at the same time. Remember your kernel drivers still treat your force control thing as a space mouse, which is used by gazebo by default. To switch this behavior off add the following lines to the *~/.gazebo/gui.ini* file:
 ```
@@ -25,5 +34,4 @@ deadband_ry = 0.1
 deadband_rz = 0.1
 topic=~/spacenav/remapped_joy_topic_to_something_not_used
 ```
-More information can be found here:
-  http://answers.gazebosim.org/question/14225/how-can-i-turn-off-the-space-navigators-control-of-the-camera/
+More information can be found [here](http://answers.gazebosim.org/question/14225/how-can-i-turn-off-the-space-navigators-control-of-the-camera/).

--- a/cartesian_controller_utilities/etc/button_cmds.yaml
+++ b/cartesian_controller_utilities/etc/button_cmds.yaml
@@ -1,0 +1,28 @@
+# Define button commands in this file
+
+# If set to False, a button cannot be pressed twice in a row.
+# Can be used to force alternation between to buttons, e.g. when doing `start recording`
+# - `stop recording` tasks.
+repeat_same_button : False
+
+# Minimum duration in seconds to pass between two buttons pressed.
+# Can be used to control the rate of pressing.
+button_sleep: 1.0
+
+# Define which commands to execute on pressing buttons
+button_cmds :
+        [
+                # button 0
+                "rosbag record /my_topic -o my_bag __name:=my_baggi",
+                # button 1
+                "rosnode kill my_baggi"
+        ]
+
+# Directories where the commands are executed
+cmd_dirs :
+        [
+                # command 0
+                "",
+                # command 1
+                ""
+        ]

--- a/cartesian_controller_utilities/launch/buttons_events.launch
+++ b/cartesian_controller_utilities/launch/buttons_events.launch
@@ -1,0 +1,7 @@
+<launch>
+        <!-- Link pressed buttons to actions -->
+        <node name="spacenav_buttons" pkg="spacenav_utils" type="buttons.py" output="screen">
+                <param name="joystick_topic" value="/spacenav/joy"/>
+                <rosparam command="load" file="$(find spacenav_utils)/etc/button_cmds.yaml" ></rosparam>
+        </node>
+</launch>

--- a/cartesian_controller_utilities/launch/buttons_events.launch
+++ b/cartesian_controller_utilities/launch/buttons_events.launch
@@ -1,7 +1,7 @@
 <launch>
         <!-- Link pressed buttons to actions -->
-        <node name="spacenav_buttons" pkg="spacenav_utils" type="buttons.py" output="screen">
+        <node name="spacenav_buttons" pkg="cartesian_controller_utilities" type="buttons.py" output="screen">
                 <param name="joystick_topic" value="/spacenav/joy"/>
-                <rosparam command="load" file="$(find spacenav_utils)/etc/button_cmds.yaml" ></rosparam>
+                <rosparam command="load" file="$(find cartesian_controller_utilities)/etc/button_cmds.yaml" ></rosparam>
         </node>
 </launch>

--- a/cartesian_controller_utilities/launch/spacenav.launch
+++ b/cartesian_controller_utilities/launch/spacenav.launch
@@ -1,0 +1,9 @@
+<launch>
+        <!-- Spacenav driver node -->
+        <node pkg="spacenav_node" type="spacenav_node" name="spacenav_node" output="screen">
+                <param name="zero_when_static" value="true"/>
+                <param name="static_count_threshold" value="30"/>
+                <rosparam param="linear_scale">[50,50,50]</rosparam>
+                <rosparam param="angular_scale">[5,5,5]</rosparam>
+        </node>
+</launch>

--- a/cartesian_controller_utilities/launch/spacenav_to_pose.launch
+++ b/cartesian_controller_utilities/launch/spacenav_to_pose.launch
@@ -1,0 +1,9 @@
+<launch>
+        <!-- Numerically integrate twists into a pose -->
+        <node name="spacenav_to_pose" pkg="spacenav_utils" type="pose.py" output="screen">
+                <param name="twist_topic" value="/spacenav/twist"/>
+                <param name="pose_topic" value="/spacenav/pose"/>
+                <param name="frame_id" value="world"/>
+                <param name="publishing_rate" value="100"/>
+        </node>
+</launch>

--- a/cartesian_controller_utilities/launch/spacenav_to_pose.launch
+++ b/cartesian_controller_utilities/launch/spacenav_to_pose.launch
@@ -1,6 +1,6 @@
 <launch>
         <!-- Numerically integrate twists into a pose -->
-        <node name="spacenav_to_pose" pkg="spacenav_utils" type="pose.py" output="screen">
+        <node name="spacenav_to_pose" pkg="cartesian_controller_utilities" type="pose.py" output="screen">
                 <param name="twist_topic" value="/spacenav/twist"/>
                 <param name="pose_topic" value="/spacenav/pose"/>
                 <param name="frame_id" value="world"/>

--- a/cartesian_controller_utilities/launch/spacenav_to_wrench.launch
+++ b/cartesian_controller_utilities/launch/spacenav_to_wrench.launch
@@ -1,0 +1,9 @@
+<launch>
+        <!-- Republish twists as wrenches -->
+        <node name="spacenav_to_wrench" pkg="spacenav_utils" type="converter.py" output="screen">
+                <param name="twist_topic" value="/spacenav/twist"/>
+                <param name="wrench_topic" value="/spacenav/wrench"/>
+                <param name="frame_id" value="world"/>
+                <param name="publishing_rate" value="100"/>
+        </node>
+</launch>

--- a/cartesian_controller_utilities/launch/spacenav_to_wrench.launch
+++ b/cartesian_controller_utilities/launch/spacenav_to_wrench.launch
@@ -1,6 +1,6 @@
 <launch>
         <!-- Republish twists as wrenches -->
-        <node name="spacenav_to_wrench" pkg="spacenav_utils" type="converter.py" output="screen">
+        <node name="spacenav_to_wrench" pkg="cartesian_controller_utilities" type="converter.py" output="screen">
                 <param name="twist_topic" value="/spacenav/twist"/>
                 <param name="wrench_topic" value="/spacenav/wrench"/>
                 <param name="frame_id" value="world"/>

--- a/cartesian_controller_utilities/package.xml
+++ b/cartesian_controller_utilities/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>spacenav_utils</name>
+  <name>cartesian_controller_utilities</name>
   <version>0.0.0</version>
   <description>Make the spacemouse a teach device for force-based teleoperation</description>
 
@@ -19,7 +19,7 @@
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/spacenav_utils</url> -->
+  <!-- <url type="website">http://wiki.ros.org/cartesian_controller_utitilies</url> -->
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->

--- a/cartesian_controller_utilities/package.xml
+++ b/cartesian_controller_utilities/package.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>spacenav_utils</name>
+  <version>0.0.0</version>
+  <description>Make the spacemouse a teach device for force-based teleoperation</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="scherzin@fzi.de">scherzin</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/spacenav_utils</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/cartesian_controller_utilities/scripts/buttons.py
+++ b/cartesian_controller_utilities/scripts/buttons.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# ROS related
+import rospy
+from sensor_msgs.msg import Joy
+
+# Other
+import subprocess
+import numpy as np
+
+class buttons:
+    """ React to button events """
+
+    def __init__(self):
+        rospy.init_node('spacenav_buttons', anonymous=False)
+
+        self.repeat_same_button = rospy.get_param('~repeat_same_button')
+        self.button_sleep = rospy.get_param('~button_sleep')
+        self.button_cmds = rospy.get_param('~button_cmds')
+        self.cmd_dirs = rospy.get_param('~cmd_dirs')
+        self.last_button_cmds = None
+
+        self.joystick_topic = rospy.get_param('~joystick_topic',default="my_joystick_topic")
+        self.sub = rospy.Subscriber(self.joystick_topic, Joy, self.event_callback, queue_size=1)
+
+    def event_callback(self,data):
+        # Have some buttons been repeatedly pressed?
+        if self.last_button_cmds and any(np.bitwise_and(data.buttons,self.last_button_cmds)):
+            return
+        for idx, val in enumerate(data.buttons):
+            if val == 1:
+                exec_dir = self.cmd_dirs[idx]
+                if not exec_dir:    # Empty string
+                    exec_dir = None
+                subprocess.Popen(
+                    self.button_cmds[idx],
+                    stdin=subprocess.PIPE,
+                    cwd=exec_dir,
+                    shell=True)
+                # Prevent pressing the same buttons in a row
+                if not self.repeat_same_button:
+                    self.last_button_cmds = data.buttons
+                rospy.sleep(self.button_sleep)
+
+
+if __name__ == '__main__':
+    _ = buttons()
+    try:
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass

--- a/cartesian_controller_utilities/scripts/converter.py
+++ b/cartesian_controller_utilities/scripts/converter.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import rospy
+from geometry_msgs.msg import Twist
+from geometry_msgs.msg import WrenchStamped
+
+
+class converter:
+    """ Convert Twist messages to WrenchStamped """
+
+    def __init__(self):
+        rospy.init_node('converter', anonymous=False)
+
+        self.twist_topic = rospy.get_param('~twist_topic',default="my_twist")
+        self.wrench_topic = rospy.get_param('~wrench_topic',default="my_wrench")
+        self.frame_id = rospy.get_param('~frame_id',default="world")
+        self.rate = rospy.Rate(rospy.get_param('~publishing_rate',default=100))
+
+        self.buffer = WrenchStamped()
+
+        self.pub = rospy.Publisher(self.wrench_topic, WrenchStamped, queue_size=3)
+        self.sub = rospy.Subscriber(self.twist_topic, Twist, self.twist_cb)
+
+
+    def twist_cb(self,data):
+        self.buffer.header.stamp     = rospy.Time.now()
+        self.buffer.header.frame_id  = self.frame_id
+        self.buffer.wrench.force.x   = data.linear.x
+        self.buffer.wrench.force.y   = data.linear.y
+        self.buffer.wrench.force.z   = data.linear.z
+        self.buffer.wrench.torque.x  = data.angular.x
+        self.buffer.wrench.torque.y  = data.angular.y
+        self.buffer.wrench.torque.z  = data.angular.z
+
+
+    def publish(self):
+        if not rospy.is_shutdown():
+            try:
+                self.pub.publish(self.buffer)
+            except rospy.ROSException:
+                # Swallow 'publish() to closed topic' error.
+                # This rarely happens on killing this node.
+                pass
+
+
+if __name__ == '__main__':
+    conv = converter()
+    try:
+        while not rospy.is_shutdown():
+            conv.publish()
+            conv.rate.sleep()
+    except rospy.ROSInterruptException:
+        pass

--- a/cartesian_controller_utilities/scripts/pose.py
+++ b/cartesian_controller_utilities/scripts/pose.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import quaternion
+import rospy
+from geometry_msgs.msg import Twist
+from geometry_msgs.msg import PoseStamped
+
+
+class converter:
+    """ Convert Twist messages to PoseStamped
+
+    Use this node to move a target pose in Cartesian space with the space
+    mouse.
+    """
+
+    def __init__(self):
+        rospy.init_node('converter', anonymous=False)
+
+        self.twist_topic = rospy.get_param('~twist_topic', default="my_twist")
+        self.pose_topic = rospy.get_param('~pose_topic', default="my_wrench")
+        self.frame_id = rospy.get_param('~frame_id', default="world")
+        self.rate = rospy.Rate(rospy.get_param('~publishing_rate', default=100))
+
+        self.buffer = PoseStamped()
+        self.rot = np.quaternion(0, 0, 0, 1)
+        self.pos = [0, 0, 0]
+
+        self.pub = rospy.Publisher(self.pose_topic, PoseStamped, queue_size=3)
+        self.sub = rospy.Subscriber(self.twist_topic, Twist, self.twist_cb)
+
+    def twist_cb(self, data):
+        """ Numerically integrate twist message into a pose
+
+        Use global self.frame_id as reference for the navigation commands.
+        """
+        dt = 0.002
+        scale = 0.01
+
+        # Position update
+        self.pos[0] += data.linear.x * dt * scale
+        self.pos[1] += data.linear.y * dt * scale
+        self.pos[2] += data.linear.z * dt * scale
+
+        # Orientation update
+        wx = data.angular.x
+        wy = data.angular.y
+        wz = data.angular.z
+
+        _, q = quaternion.integrate_angular_velocity(lambda _: (wx, wy, wz), 0, dt, self.rot)
+
+        self.rot = q[-1]  # the last one is after dt passed
+
+        self.buffer.header.stamp = rospy.Time.now()
+        self.buffer.header.frame_id = self.frame_id
+        self.buffer.pose.position.x = self.pos[0]
+        self.buffer.pose.position.y = self.pos[1]
+        self.buffer.pose.position.z = self.pos[2]
+        self.buffer.pose.orientation.x = self.rot.x
+        self.buffer.pose.orientation.y = self.rot.y
+        self.buffer.pose.orientation.z = self.rot.z
+        self.buffer.pose.orientation.w = self.rot.w
+
+    def publish(self):
+        if not rospy.is_shutdown():
+            try:
+                self.pub.publish(self.buffer)
+            except rospy.ROSException:
+                # Swallow 'publish() to closed topic' error.
+                # This rarely happens on killing this node.
+                pass
+
+
+if __name__ == '__main__':
+    conv = converter()
+    try:
+        while not rospy.is_shutdown():
+            conv.publish()
+            conv.rate.sleep()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
## Motivation
The stability of the `cartesian_force_controller` and the `cartesian_compliance_controller` depends on the environment's stiffness and varies with each use case. While feeling natural and responsive in free motion, the robot's sensitivity normally is decreased in contact to remedy oscillations. Users thus often set the controller gains conservatively low for the *worst* case, i.e. loosing some of the possible sensitivity in free motion.

## Approach
Frequency domain-based stability observers could automatically detect oscillations (before they become apparent to the user's eye and touch) and decrease the controller gains adequately. Here's a [very promising approach](https://ieeexplore.ieee.org/abstract/document/7384497) that does this directly on the force-torque sensor signals. Let's see if we can integrate this into the `cartesian_controllers`.

## Steps
- [ ] Write a Python node that listens to the sensor topic
- [ ] Perform FFT on a respective window and compute the stability indices from the paper
- [ ] Check whether to increase the virtual model's end-effector mass (currently not exposed as dynamic parameter) or decrease the `error_scale`
- [ ] Test the functionality with the spacenav device as sensor in simulation
- [ ] Test this on a real URe robot