### PR TITLE
Fix to gravity compensation calculation

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -120,7 +120,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @return The quantity in the robot base frame
      */
-    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from);
+    KDL::Wrench displayInBaseLink(const KDL::Wrench& vector, const std::string& from);
 
     /**
      * @brief Display the given tensor in the robot base frame
@@ -142,7 +142,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @return The quantity in the new frame
      */
-    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
+    KDL::Wrench displayInTipLink(const KDL::Wrench& vector, const std::string& to);
 
     /**
      * @brief Check if specified links are part of the robot chain

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -254,16 +254,9 @@ computeJointControlCmds(const ctrl::Vector6D& error, const ros::Duration& period
 }
 
 template <class HardwareInterface>
-ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
-displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
+KDL::Wrench CartesianControllerBase<HardwareInterface>::
+displayInBaseLink(const KDL::Wrench& vector, const std::string& from)
 {
-  // Adjust format
-  KDL::Wrench wrench_kdl;
-  for (int i = 0; i < 6; ++i)
-  {
-    wrench_kdl(i) = vector[i];
-  }
-
   KDL::Frame transform_kdl;
   m_forward_kinematics_solver->JntToCart(
       m_ik_solver->getPositions(),
@@ -271,16 +264,7 @@ displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
       from);
 
   // Rotate into new reference frame
-  wrench_kdl = transform_kdl.M * wrench_kdl;
-
-  // Reassign
-  ctrl::Vector6D out;
-  for (int i = 0; i < 6; ++i)
-  {
-    out[i] = wrench_kdl(i);
-  }
-
-  return out;
+  return transform_kdl.M * vector;
 }
 
 template <class HardwareInterface>
@@ -317,16 +301,9 @@ displayInBaseLink(const ctrl::Matrix6D& tensor, const std::string& from)
 }
 
 template <class HardwareInterface>
-ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
-displayInTipLink(const ctrl::Vector6D& vector, const std::string& to)
+KDL::Wrench CartesianControllerBase<HardwareInterface>::
+displayInTipLink(const KDL::Wrench& vector, const std::string& to)
 {
-  // Adjust format
-  KDL::Wrench wrench_kdl;
-  for (int i = 0; i < 6; ++i)
-  {
-    wrench_kdl(i) = vector[i];
-  }
-
   KDL::Frame transform_kdl;
   m_forward_kinematics_solver->JntToCart(
       m_ik_solver->getPositions(),
@@ -334,16 +311,7 @@ displayInTipLink(const ctrl::Vector6D& vector, const std::string& to)
       to);
 
   // Rotate into new reference frame
-  wrench_kdl = transform_kdl.M.Inverse() * wrench_kdl;
-
-  // Reassign
-  ctrl::Vector6D out;
-  for (int i = 0; i < 6; ++i)
-  {
-    out[i] = wrench_kdl(i);
-  }
-
-  return out;
+  return transform_kdl.M.Inverse() * vector;
 }
 
 template <class HardwareInterface>

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -104,7 +104,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     void setFtSensorReferenceFrame(const std::string& new_ref);
 
   private:
-    ctrl::Vector6D        compensateGravity();
+    void                  compensateGravity(KDL::Wrench& ft_sensor_wrench);
 
     void targetWrenchCallback(const geometry_msgs::WrenchStamped& wrench);
     void ftSensorWrenchCallback(const geometry_msgs::WrenchStamped& wrench);
@@ -113,11 +113,11 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     ros::ServiceServer    m_signal_taring_server;
     ros::Subscriber       m_target_wrench_subscriber;
     ros::Subscriber       m_ft_sensor_wrench_subscriber;
-    ctrl::Vector6D        m_target_wrench;
-    ctrl::Vector6D        m_ft_sensor_wrench;
-    ctrl::Vector6D        m_weight_force;
-    ctrl::Vector6D        m_grav_comp_during_taring;
-    ctrl::Vector3D        m_center_of_mass;
+    KDL::Wrench           m_target_wrench;
+    KDL::Wrench           m_ft_sensor_wrench;
+    KDL::Wrench           m_weight_force;
+    KDL::Wrench           m_grav_comp_during_taring;
+    KDL::Vector           m_center_of_mass;
     std::string           m_ft_sensor_ref_link;
     KDL::Frame            m_ft_sensor_transform;
 

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -279,6 +279,12 @@ template <class HardwareInterface>
 bool CartesianForceController<HardwareInterface>::
 signalTaringCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res)
 {
+  // Get latest joint positions in case we are not running
+  if (!Base::isRunning())
+  {
+    Base::m_ik_solver->setStartState(Base::m_joint_handles);
+  }
+
   // Compute current gravity effects in sensor frame
   ctrl::Vector6D tmp = Base::displayInTipLink(m_weight_force,m_ft_sensor_ref_link);
   tmp.tail<3>() = m_center_of_mass.cross(tmp.head<3>()); // M = r x F


### PR DESCRIPTION
Fix to gravity compensation calculation, as mentioned in #39
The modification additionally changed variables from ctrl::Vector6D to KDL::Wrench to reduce format translation in displayInBaseLink() and displayInTipLink(). This is because such modification is closer to my working and tested copy. It is possible to convert them back to ctrl::Vector6D, but you should spend time doing tests again.