### PR TITLE
Fix joint to cartesian controller's robot chain

### DIFF
--- a/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
+++ b/joint_to_cartesian_controller/include/joint_to_cartesian_controller/joint_to_cartesian_controller.h
@@ -100,6 +100,7 @@ class JointToCartesianController
 
     JointControllerAdapter     m_controller_adapter;
 
+    KDL::Chain m_robot_chain;
     std::vector<
       hardware_interface::JointStateHandle>   m_joint_handles;
 

--- a/joint_to_cartesian_controller/src/joint_to_cartesian_controller.cpp
+++ b/joint_to_cartesian_controller/src/joint_to_cartesian_controller.cpp
@@ -88,7 +88,6 @@ bool JointToCartesianController::init(hardware_interface::JointStateInterface* h
   std::string robot_description;
   urdf::Model robot_model;
   KDL::Tree   robot_tree;
-  KDL::Chain  robot_chain;
 
   // Get controller specific configuration
   if (!nh.getParam("/robot_description",robot_description))
@@ -132,7 +131,7 @@ bool JointToCartesianController::init(hardware_interface::JointStateInterface* h
     ROS_ERROR_STREAM(error);
     throw std::runtime_error(error);
   }
-  if (!robot_tree.getChain(m_robot_base_link,m_end_effector_link,robot_chain))
+  if (!robot_tree.getChain(m_robot_base_link,m_end_effector_link, m_robot_chain))
   {
     const std::string error = ""
       "Failed to parse robot chain from urdf model. "
@@ -165,7 +164,7 @@ bool JointToCartesianController::init(hardware_interface::JointStateInterface* h
   m_controller_manager.reset(new controller_manager::ControllerManager(&m_controller_adapter, nh));
 
   // Initialize forward kinematics solver
-  m_fk_solver.reset(new KDL::ChainFkSolverPos_recursive(robot_chain));
+  m_fk_solver.reset(new KDL::ChainFkSolverPos_recursive(m_robot_chain));
 
   return true;
 }


### PR DESCRIPTION
The solver keeps an internal const ref.
We need to have the robot chain as member to avoid segfaults. This is equivalent to [this fix](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/commit/5e6e23876e3b56bb6d3b36d49fa1d3c96e3a5d0a).

Thanks to @matthias-mayr for spotting this.