### PR TITLE
Support a clang-based build pipeline

### DIFF
--- a/.github/workflows/industrial_ci_noetic_action.yml
+++ b/.github/workflows/industrial_ci_noetic_action.yml
@@ -4,6 +4,11 @@ on: [push, pull_request]
 
 jobs:
   industrial_ci:
+    env:
+      # See the full documentation here:
+      # https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst
+      CXX: /usr/bin/clang++
+      CC: /usr/bin/clang
     strategy:
       fail-fast: false
       matrix:

--- a/cartesian_controller_base/package.xml
+++ b/cartesian_controller_base/package.xml
@@ -39,6 +39,10 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- For reproducing #99 -->
+  <build_depend>clang</build_depend>
+  <buildtool_depend>clang</buildtool_depend>
+
   <build_depend>roscpp</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>kdl_parser</build_depend>


### PR DESCRIPTION
## Goal
Check and assure that the `cartesian_controllers` work with the `clang` compiler.

## Steps
- [x] Switch to clang via the `CC` and `CXX` environment variables (only Noetic, keep Melodic with `GCC`)
- [x] Confirm #99 in CI
- [x] Reproduce this locally
- [ ] Debug what's happening
- [ ] apply fixes and recheck that `GCC` still works (checked by CI Melodic)
---
- Just found out that I get the same error with GCC when removing `src/IKSolver.cpp` from `add_library(${PROJECT_NAME}
`. That's a hint..

---
Fix #99 