### PR TITLE
Publish state feedback for controllers

### DIFF
--- a/cartesian_controller_base/cfg/CartesianController.cfg
+++ b/cartesian_controller_base/cfg/CartesianController.cfg
@@ -7,5 +7,6 @@ gen = ParameterGenerator()
 
 gen.add("error_scale", double_t, 0, "Scale the PID controlled error uniformly with this value", 1.0, 0.0, 10)
 gen.add("iterations", int_t, 0, "Number of solver iterations per control cycle", 10, 1, 100)
+gen.add("publish_state_feedback",   bool_t,   0, "Whether or not to publish the controller's current end-effector pose and twist",  False)
 
 exit(gen.generate(PACKAGE, "cartesian_controller_base", "CartesianController"))

--- a/resources/doc/Solver_details.md
+++ b/resources/doc/Solver_details.md
@@ -39,7 +39,7 @@ Unfortunately, there won't exist ideal parameters for every use case and robot.
 So, for your specific application, you will be tweaking the PD gains at some point.
 
 ### Solver parameters
-The common solver has two parameters:
+The common solver has three parameters:
 * **iterations**: The number of internally simulated cycles per control cycle.
   Increasing this number will give the solver more iterations to approach the given target.
   A value of `10` is a good default for the `CartesianMotionController` and the `CartesianComplianceController`.
@@ -50,6 +50,33 @@ The common solver has two parameters:
   6-dimensional PD controlled error (both translation and rotation alike).
   Use this parameter to find the right range
   for your PD gains. It's handy to use the slider in dynamic reconfigure for this.
+
+* **publish_state_feedback**: A boolean flag whether to publish the
+  controller-internal state. This is helpful for comparing the controllers'
+  feedback against the given target reference during parameter tweaking. If
+  `true`, each controller will publish its end-effector pose and twist on the local topics `current_pose` and
+  `current_twist`, respectively. You can easily find them in a sourced terminal with
+  ```bash
+  rostopic list | grep current
+  ```
+
+All solver parameters can be set online via `dynamic_reconfigure` in the controllers'
+`solver` namespace, or at startup via the controller's `.yaml` configuration
+file, e.g. with
+```yaml
+my_cartesian_controller:
+    # Type, link and joints specification here
+    # ...
+
+    solver:
+        error_scale: 0.5
+        iterations: 5
+        publish_state_feedback: True
+
+    # Further specification
+    # ...
+
+```
 
 ## Performance
 As a default, please build the cartesian_controllers in release mode:


### PR DESCRIPTION
## Goal
Publish the controllers' internal current state for debugging and controller parameter tweaking.

## Steps
- [x] Publish the current end-effector pose
- [x] Publish the current end-effector twist
- [x] Activate publishing via parameter. It should be *off* by default.
- [x] Add documentation on this feature
- [x] Open a PR for ROS2 (#113)

---
Implements #111 