### PR TITLE
Feature/reconfigure cart compliance controller

### DIFF
--- a/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
+++ b/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
@@ -122,6 +122,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
                         m_compliance_ref_link << " is not part of the kinematic chain from "
                                               << Base::m_robot_base_link << " to "
                                               << Base::m_end_effector_link);
+    release_interfaces();                                              
     return TYPE::ERROR;
   }
 

--- a/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
+++ b/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
@@ -99,19 +99,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
     return TYPE::ERROR;
   }
 
-  // Make sure compliance link is part of the robot chain
-  m_compliance_ref_link = get_node()->get_parameter("compliance_ref_link").as_string();
-  if(!Base::robotChainContains(m_compliance_ref_link))
-  {
-    RCLCPP_ERROR_STREAM(get_node()->get_logger(),
-                        m_compliance_ref_link << " is not part of the kinematic chain from "
-                                              << Base::m_robot_base_link << " to "
-                                              << Base::m_end_effector_link);
-    return TYPE::ERROR;
-  }
 
-  // Make sure sensor wrenches are interpreted correctly
-  ForceBase::setFtSensorReferenceFrame(m_compliance_ref_link);
 
   return TYPE::SUCCESS;
 }
@@ -126,6 +114,20 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
   {
     return TYPE::ERROR;
   }
+    // Make sure compliance link is part of the robot chain
+  m_compliance_ref_link = get_node()->get_parameter("compliance_ref_link").as_string();
+  if(!Base::robotChainContains(m_compliance_ref_link))
+  {
+    RCLCPP_ERROR_STREAM(get_node()->get_logger(), "[CartesianComplianceController]: " <<
+                        m_compliance_ref_link << " is not part of the kinematic chain from "
+                                              << Base::m_robot_base_link << " to "
+                                              << Base::m_end_effector_link);
+    return TYPE::ERROR;
+  }
+
+  // Make sure sensor wrenches are interpreted correctly
+  ForceBase::setFtSensorReferenceFrame(m_compliance_ref_link);
+
   return TYPE::SUCCESS;
 }
 

--- a/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
+++ b/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
@@ -147,7 +147,10 @@ namespace cartesian_controller_base{
     m_jnt_space_inertia.resize(m_number_joints);
 
     // Set the initial value if provided at runtime, else use default value.
-    m_min = nh->declare_parameter<double>(m_params + "/link_mass", 0.1);
+    if(!nh->has_parameter(m_params + "/link_mass"))
+      m_min = nh->declare_parameter<double>(m_params + "/link_mass", 0.1);
+    else
+      m_min = nh->get_parameter(m_params + "/link_mass").get_value<double>();
 
     RCLCPP_INFO(nh->get_logger(), "Forward dynamics solver initialized");
     RCLCPP_INFO(nh->get_logger(), "Forward dynamics solver has control over %i joints", m_number_joints);

--- a/cartesian_force_controller/src/cartesian_force_controller.cpp
+++ b/cartesian_force_controller/src/cartesian_force_controller.cpp
@@ -115,6 +115,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
                         m_ft_sensor_ref_link << " is not part of the kinematic chain from "
                                              << Base::m_robot_base_link << " to "
                                              << Base::m_end_effector_link);
+    release_interfaces();
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
   }
 

--- a/cartesian_motion_controller/src/cartesian_motion_controller.cpp
+++ b/cartesian_motion_controller/src/cartesian_motion_controller.cpp
@@ -97,6 +97,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn Cartes
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn CartesianMotionController::on_activate(
     const rclcpp_lifecycle::State & previous_state)
 {
+  RCLCPP_INFO_STREAM(get_node()->get_logger(), "[CartesianMotionController] activating");
   Base::on_activate(previous_state);
 
   // Reset simulation with real joint state


### PR DESCRIPTION
# Should not be merged like this!

PR for #127 

This is currently a proof of concept which seems to work on my setup. It still generates quite a lot of errors which do not seem to matter to much apparently as the test itself works.


# Test setup

For testing purpose I have `cartesian_complianct_controller_bottom` in my `controller.yaml`.
The default `end_effector_link` and `compliance_ref_link` is `ur_bot/magnet_gripper/attach`
For testing I changed both to `gripper_bot/center`

```
cartesian_compliance_controller_bottom:
  ros__parameters:
    end_effector_link: "ur_bot/magnet_gripper/attach"
    robot_base_link: "ur_bot/base_link"
    ft_sensor_ref_link: "ur_bot/tool0"
    compliance_ref_link: "ur_bot/magnet_gripper/attach"
    joints:
      - ur_bot/shoulder_pan_joint
      - ur_bot/shoulder_lift_joint
      - ur_bot/elbow_joint
      - ur_bot/wrist_1_joint
      - ur_bot/wrist_2_joint
      - ur_bot/wrist_3_joint

    # Choose: position or velocity.
    command_interfaces:
      - position
        #- velocity

    stiffness:  # w.r.t. compliance_ref_link
        trans_x: 8900.0
        trans_y: 900.0
        trans_z: 900.0
        rot_x: 40.0
        rot_y: 40.0
        rot_z: 40.0

    solver:
        error_scale: 0.68
        iterations: 2

    pd_gains:
        trans_x: {p: 0.011, d: 0.00}
        trans_y: {p: 0.011, d: 0.00}
        trans_z: {p: 0.011, d: 0.00}
        rot_x: {p: 0.3}
        rot_y: {p: 0.3}
        rot_z: {p: 0.3}

```

```
#Load controller
ros2 control load_controller --set-state active cartesian_compliance_controller_bottom

#Deactivate controller
ros2 control set_controller_state cartesian_compliance_controller_bottom inactive

#Perform parameter calls
ros2 param set /cartesian_compliance_controller_bottom end_effector_link gripper_bot/center
ros2 param set /cartesian_compliance_controller_bottom compliance_ref_link gripper_bot/center

#Reactivate controller
ros2 control set_controller_state cartesian_compliance_controller_bottom active 

#Then run a program which plans and execute a trajectory
```

The way I implemented this is a bit nasty:

1. I simply added a on_configure call in the on_activate method of the cart. compl. controller

```
rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn CartesianComplianceController::on_activate(
    const rclcpp_lifecycle::State & previous_state)
{

  on_configure(previous_state);
```

2. In the base class I removed the check if the base controller is already configured

```
rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn CartesianControllerBase::on_configure(
    const rclcpp_lifecycle::State & previous_state)
{
  /*if (m_configured)
  {
    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
  }*/
```

3.  In the ForwardDynamicsSolver I had to check if the link_mass parameter was already declared:

```
    // Set the initial value if provided at runtime, else use default value.
    if(!nh->has_parameter(m_params + "/link_mass"))
      m_min = nh->declare_parameter<double>(m_params + "/link_mass", 0.1);
```

# Issues

```
[ros2_control_node-10] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[ros2_control_node-10]          at line 127 in ./src/class_loader.cpp
[ros2_control_node-10] [INFO] [1685083683.473031148] [cartesian_compliance_controller_bottom]: Forward dynamics solver initialized
[ros2_control_node-10] [INFO] [1685083683.473061815] [cartesian_compliance_controller_bottom]: Forward dynamics solver has control over 6 joints
[ros2_control_node-10] Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
[ros2_control_node-10]          at line 127 in ./src/class_loader.cpp
[ros2_control_node-10] [INFO] [1685083683.483277420] [cartesian_compliance_controller_bottom]: Forward dynamics solver initialized
[ros2_control_node-10] [INFO] [1685083683.483303519] [cartesian_compliance_controller_bottom]: Forward dynamics solver has control over 6 joints
```

I would guess this is somehow related to the multi inheritence used in the cart. compliance. controller. Nevertheless they should be fixed as they sound link a memory leak. 



# In order to do this properly I suggest:

1. m_min parameter should be passed to the FowardDynamicsSolver from the Caller instead of declaring it internally
2. In the CartesianControllerBase seperate general init calls from the once creating the kinematics chain and move the later into an extra method -> By avoiding to call on_configure again I think the warning from the ClassLoader should prob. also be solved.
3. In the cartesian compliance controller just reread the `ref_link` and reinit the kinematic chain. -> Just do the bare minimum as on_activate will always run in the RT loop of ros2control

But I won't starting on these points without any feedback from @stefanscherzinger 