### PR TITLE
Improve callbacks for active controllers

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -181,7 +181,7 @@ protected:
    *
    * @return True if the controller is active, false otherwise
    */
-  bool isActive() const {return m_active;};
+  bool isActive() const { return m_active; };
 
   KDL::Chain m_robot_chain;
 

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -176,6 +176,13 @@ protected:
     return false;
   }
 
+  /**
+   * @brief Helper method to check the controller's state during input callbacks
+   *
+   * @return True if the controller is active, false otherwise
+   */
+  bool isActive() const {return m_active;};
+
   KDL::Chain m_robot_chain;
 
   std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;

--- a/cartesian_controller_tests/integration_tests/integration_tests.py
+++ b/cartesian_controller_tests/integration_tests/integration_tests.py
@@ -155,44 +155,47 @@ class IntegrationTest(unittest.TestCase):
         The controllers' callbacks store them even when in inactive state after startup.
         We then check if every controller can be activated normally.
         """
+
         def publish_nan_targets():
             # Target pose
             target_pose = PoseStamped()
             target_pose.header.frame_id = "base_link"
-            target_pose.pose.position.x = float('nan')
-            target_pose.pose.position.y = float('nan')
-            target_pose.pose.position.z = float('nan')
-            target_pose.pose.orientation.x = float('nan')
-            target_pose.pose.orientation.y = float('nan')
-            target_pose.pose.orientation.z = float('nan')
-            target_pose.pose.orientation.w = float('nan')
+            target_pose.pose.position.x = float("nan")
+            target_pose.pose.position.y = float("nan")
+            target_pose.pose.position.z = float("nan")
+            target_pose.pose.orientation.x = float("nan")
+            target_pose.pose.orientation.y = float("nan")
+            target_pose.pose.orientation.z = float("nan")
+            target_pose.pose.orientation.w = float("nan")
             self.target_pose_pub.publish(target_pose)
 
             # Force-torque sensor
             ft_sensor_wrench = WrenchStamped()
-            ft_sensor_wrench.wrench.force.x = float('nan')
-            ft_sensor_wrench.wrench.force.y = float('nan')
-            ft_sensor_wrench.wrench.force.z = float('nan')
-            ft_sensor_wrench.wrench.torque.x = float('nan')
-            ft_sensor_wrench.wrench.torque.y = float('nan')
-            ft_sensor_wrench.wrench.torque.z = float('nan')
+            ft_sensor_wrench.wrench.force.x = float("nan")
+            ft_sensor_wrench.wrench.force.y = float("nan")
+            ft_sensor_wrench.wrench.force.z = float("nan")
+            ft_sensor_wrench.wrench.torque.x = float("nan")
+            ft_sensor_wrench.wrench.torque.y = float("nan")
+            ft_sensor_wrench.wrench.torque.z = float("nan")
             self.ft_sensor_wrench_pub.publish(ft_sensor_wrench)
 
             # Target wrench
             target_wrench = WrenchStamped()
-            target_wrench.wrench.force.x = float('nan')
-            target_wrench.wrench.force.y = float('nan')
-            target_wrench.wrench.force.z = float('nan')
-            target_wrench.wrench.torque.x = float('nan')
-            target_wrench.wrench.torque.y = float('nan')
-            target_wrench.wrench.torque.z = float('nan')
+            target_wrench.wrench.force.x = float("nan")
+            target_wrench.wrench.force.y = float("nan")
+            target_wrench.wrench.force.z = float("nan")
+            target_wrench.wrench.torque.x = float("nan")
+            target_wrench.wrench.torque.y = float("nan")
+            target_wrench.wrench.torque.z = float("nan")
             self.target_wrench_pub.publish(target_wrench)
 
         for name in self.our_controllers:
             self.start_controller(name)
             publish_nan_targets()
-            time.sleep(3) # process some update() cycles
-            self.assertTrue(self.check_state(name, 'active'), f"{name} survives inputs with NaNs")
+            time.sleep(3)  # process some update() cycles
+            self.assertTrue(
+                self.check_state(name, "active"), f"{name} survives inputs with NaNs"
+            )
             self.stop_controller(name)
 
     def check_state(self, controller, state):

--- a/cartesian_controller_tests/integration_tests/integration_tests.py
+++ b/cartesian_controller_tests/integration_tests/integration_tests.py
@@ -155,46 +155,44 @@ class IntegrationTest(unittest.TestCase):
         The controllers' callbacks store them even when in inactive state after startup.
         We then check if every controller can be activated normally.
         """
-        # Target pose
-        target_pose = PoseStamped()
-        target_pose.header.frame_id = "base_link"
-        target_pose.pose.position.x = float("nan")
-        target_pose.pose.position.y = float("nan")
-        target_pose.pose.position.z = float("nan")
-        target_pose.pose.orientation.x = float("nan")
-        target_pose.pose.orientation.y = float("nan")
-        target_pose.pose.orientation.z = float("nan")
-        target_pose.pose.orientation.w = float("nan")
-        self.target_pose_pub.publish(target_pose)
+        def publish_nan_targets():
+            # Target pose
+            target_pose = PoseStamped()
+            target_pose.header.frame_id = "base_link"
+            target_pose.pose.position.x = float('nan')
+            target_pose.pose.position.y = float('nan')
+            target_pose.pose.position.z = float('nan')
+            target_pose.pose.orientation.x = float('nan')
+            target_pose.pose.orientation.y = float('nan')
+            target_pose.pose.orientation.z = float('nan')
+            target_pose.pose.orientation.w = float('nan')
+            self.target_pose_pub.publish(target_pose)
 
-        # Force-torque sensor
-        ft_sensor_wrench = WrenchStamped()
-        ft_sensor_wrench.wrench.force.x = float("nan")
-        ft_sensor_wrench.wrench.force.y = float("nan")
-        ft_sensor_wrench.wrench.force.z = float("nan")
-        ft_sensor_wrench.wrench.torque.x = float("nan")
-        ft_sensor_wrench.wrench.torque.y = float("nan")
-        ft_sensor_wrench.wrench.torque.z = float("nan")
-        self.ft_sensor_wrench_pub.publish(ft_sensor_wrench)
+            # Force-torque sensor
+            ft_sensor_wrench = WrenchStamped()
+            ft_sensor_wrench.wrench.force.x = float('nan')
+            ft_sensor_wrench.wrench.force.y = float('nan')
+            ft_sensor_wrench.wrench.force.z = float('nan')
+            ft_sensor_wrench.wrench.torque.x = float('nan')
+            ft_sensor_wrench.wrench.torque.y = float('nan')
+            ft_sensor_wrench.wrench.torque.z = float('nan')
+            self.ft_sensor_wrench_pub.publish(ft_sensor_wrench)
 
-        # Target wrench
-        target_wrench = WrenchStamped()
-        target_wrench.wrench.force.x = float("nan")
-        target_wrench.wrench.force.y = float("nan")
-        target_wrench.wrench.force.z = float("nan")
-        target_wrench.wrench.torque.x = float("nan")
-        target_wrench.wrench.torque.y = float("nan")
-        target_wrench.wrench.torque.z = float("nan")
-        self.target_wrench_pub.publish(target_wrench)
-
-        time.sleep(1)  # give the controllers some time to process
+            # Target wrench
+            target_wrench = WrenchStamped()
+            target_wrench.wrench.force.x = float('nan')
+            target_wrench.wrench.force.y = float('nan')
+            target_wrench.wrench.force.z = float('nan')
+            target_wrench.wrench.torque.x = float('nan')
+            target_wrench.wrench.torque.y = float('nan')
+            target_wrench.wrench.torque.z = float('nan')
+            self.target_wrench_pub.publish(target_wrench)
 
         for name in self.our_controllers:
             self.start_controller(name)
-            time.sleep(3)  # process some update() cycles
-            self.assertTrue(
-                self.check_state(name, "active"), f"{name} survives inputs with NaNs"
-            )
+            publish_nan_targets()
+            time.sleep(3) # process some update() cycles
+            self.assertTrue(self.check_state(name, 'active'), f"{name} survives inputs with NaNs")
             self.stop_controller(name)
 
     def check_state(self, controller, state):

--- a/cartesian_force_controller/src/cartesian_force_controller.cpp
+++ b/cartesian_force_controller/src/cartesian_force_controller.cpp
@@ -209,6 +209,11 @@ void CartesianForceController::setFtSensorReferenceFrame(const std::string & new
 void CartesianForceController::targetWrenchCallback(
   const geometry_msgs::msg::WrenchStamped::SharedPtr wrench)
 {
+  if (!this->isActive())
+  {
+    return;
+  }
+
   if (std::isnan(wrench->wrench.force.x) || std::isnan(wrench->wrench.force.y) ||
       std::isnan(wrench->wrench.force.z) || std::isnan(wrench->wrench.torque.x) ||
       std::isnan(wrench->wrench.torque.y) || std::isnan(wrench->wrench.torque.z))
@@ -230,6 +235,11 @@ void CartesianForceController::targetWrenchCallback(
 void CartesianForceController::ftSensorWrenchCallback(
   const geometry_msgs::msg::WrenchStamped::SharedPtr wrench)
 {
+  if (!this->isActive())
+  {
+    return;
+  }
+
   if (std::isnan(wrench->wrench.force.x) || std::isnan(wrench->wrench.force.y) ||
       std::isnan(wrench->wrench.force.z) || std::isnan(wrench->wrench.torque.x) ||
       std::isnan(wrench->wrench.torque.y) || std::isnan(wrench->wrench.torque.z))

--- a/cartesian_motion_controller/src/cartesian_motion_controller.cpp
+++ b/cartesian_motion_controller/src/cartesian_motion_controller.cpp
@@ -193,6 +193,11 @@ ctrl::Vector6D CartesianMotionController::computeMotionError()
 void CartesianMotionController::targetFrameCallback(
   const geometry_msgs::msg::PoseStamped::SharedPtr target)
 {
+  if (!this->isActive())
+  {
+    return;
+  }
+
   if (std::isnan(target->pose.position.x) || std::isnan(target->pose.position.y) ||
       std::isnan(target->pose.position.z) || std::isnan(target->pose.orientation.x) ||
       std::isnan(target->pose.orientation.y) || std::isnan(target->pose.orientation.z) ||


### PR DESCRIPTION
## Steps

- [x] Controllers process input only when active
- [x] Adapt the integration test for `NaN`
- ~~[ ] Use *child loggers* for the `NaN` warnings. This allows users to switch them off when working with fake hardware.~~ (handled in #183)

---
Fixes #130 