### PR TITLE
Docs: Mentions setting the link mass in YAML

### DIFF
--- a/cartesian_compliance_controller/README.md
+++ b/cartesian_compliance_controller/README.md
@@ -53,6 +53,8 @@ my_cartesian_compliance_controller:
 
     solver:
         error_scale: 0.5
+        forward_dynamics:
+            link_mass: 0.1
 
     pd_gains:
         trans_x: {p: 0.05}

--- a/cartesian_controller_examples/config/example_controllers.yaml
+++ b/cartesian_controller_examples/config/example_controllers.yaml
@@ -34,6 +34,8 @@ my_cartesian_force_controller:
 
     solver:
         error_scale: 0.5
+        forward_dynamics:
+            link_mass: 0.1
 
     pd_gains:
         trans_x: {p: 0.05}
@@ -69,6 +71,8 @@ my_cartesian_compliance_controller:
 
     solver:
         error_scale: 0.5
+        forward_dynamics:
+            link_mass: 0.1
 
     pd_gains:
         trans_x: {p: 0.05}

--- a/resources/doc/Solver_details.md
+++ b/resources/doc/Solver_details.md
@@ -72,6 +72,8 @@ my_cartesian_controller:
         error_scale: 0.5
         iterations: 5
         publish_state_feedback: True
+        forward_dynamics:
+            link_mass: 0.1
 
     # Further specification
     # ...


### PR DESCRIPTION
For my current setup, I am seeing better behavior during interactions with a smaller link mass.
It took me some minutes to find out how to set it in YAML. This should make it easier for other people.