### PR TITLE
Remove *testing* ci pipelines for unsupported versions

### DIFF
--- a/.github/workflows/industrial_ci_foxy_action.yml
+++ b/.github/workflows/industrial_ci_foxy_action.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {ROS_DISTRO: foxy, ROS_REPO: testing}
           - {ROS_DISTRO: foxy, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/industrial_ci_galactic_action.yml
+++ b/.github/workflows/industrial_ci_galactic_action.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {ROS_DISTRO: galactic, ROS_REPO: testing}
           - {ROS_DISTRO: galactic, ROS_REPO: main}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
There won't be any development on deprecated versions, so drop them and keep the CI a little more light-weight.