### PR TITLE
Add optionnal end effector transform offset for the cartesian force controller

### DIFF
--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -124,6 +124,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      * @return The quantity in the robot base frame
      */
     ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_transform_offset);
 
     /**
      * @brief Display the given tensor in the robot base frame
@@ -169,6 +170,8 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
     KDL::Chain m_robot_chain;
 
     std::shared_ptr<KDL::TreeFkSolverPos_recursive> m_forward_kinematics_solver;
+
+    const KDL::Frame m_identity_transform_kdl;
 
     /**
      * @brief Allow users to choose the IK solver type on startup

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -276,6 +276,13 @@ template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
 displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
 {
+ return displayInBaseLink(vector,from,m_identity_transform_kdl);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_transform_offset)
+{
   // Adjust format
   KDL::Wrench wrench_kdl;
   for (int i = 0; i < 6; ++i)
@@ -288,6 +295,9 @@ displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
       m_ik_solver->getPositions(),
       transform_kdl,
       from);
+
+  // Apply offset
+  transform_kdl = transform_kdl * from_transform_offset;
 
   // Rotate into new reference frame
   wrench_kdl = transform_kdl.M * wrench_kdl;

--- a/cartesian_force_controller/README.md
+++ b/cartesian_force_controller/README.md
@@ -24,6 +24,7 @@ my_cartesian_force_controller:
     end_effector_link: "tool0"
     robot_base_link: "base_link"
     ft_sensor_ref_link: "sensor_link"
+    hand_frame_control: true
     joints:
     - joint1
     - joint2

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -102,6 +102,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     ctrl::Vector6D        computeForceError();
     std::string           m_new_ft_sensor_ref;
     void setFtSensorReferenceFrame(const std::string& new_ref);
+    void setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_transform_offset);
 
   private:
     ctrl::Vector6D        compensateGravity();

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -121,6 +121,8 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     ctrl::Vector3D        m_center_of_mass;
     std::string           m_ft_sensor_ref_link;
     KDL::Frame            m_ft_sensor_transform;
+    KDL::Frame            m_end_effector_transform_offset; // only used when m_hand_frame_control = True
+
 
     /**
      * Allow users to choose whether to specify their target wrenches in the

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -78,6 +78,26 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     }
   }
 
+  // Optionnaly add end effector transform offset
+  if(nh.hasParam("end_effector_transform_offset"))
+  {
+    std::array<std::string, 7> pose_params_str{"x", "y", "z", "qx", "qy", "qz", "qw"};
+    std::array<double, 7> pose_params_val;
+
+    for (size_t i = 0; i < pose_params_str.size(); ++i)
+    {
+      if (!nh.getParam("end_effector_transform_offset/" + pose_params_str[i],pose_params_val[i]))
+      {
+        ROS_ERROR_STREAM("Failed to load " << nh.getNamespace() + "/end_effector_transform_offset/" << pose_params_str[i] << " from parameter server");
+        return false;
+      }
+    }
+    KDL::Vector vector = KDL::Vector(pose_params_val[0],pose_params_val[1],pose_params_val[2]);
+    KDL::Rotation rotation = KDL::Rotation::Quaternion(pose_params_val[3],pose_params_val[4],pose_params_val[5],pose_params_val[6]);
+
+    m_end_effector_transform_offset = KDL::Frame(rotation,vector);
+  }
+
   // Make sure sensor link is part of the robot chain
   if(!Base::robotChainContains(m_ft_sensor_ref_link))
   {

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -204,6 +204,13 @@ template <class HardwareInterface>
 void CartesianForceController<HardwareInterface>::
 setFtSensorReferenceFrame(const std::string& new_ref)
 {
+  setFtSensorReferenceFrame(new_ref, Base::m_identity_transform_kdl);
+}
+
+template <class HardwareInterface>
+void CartesianForceController<HardwareInterface>::
+setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_transform_offset)
+{
   // Compute static transform from the force torque sensor to the new reference
   // frame of interest.
   m_new_ft_sensor_ref = new_ref;
@@ -223,6 +230,8 @@ setFtSensorReferenceFrame(const std::string& new_ref)
       jnts,
       new_sensor_ref,
       m_new_ft_sensor_ref);
+
+  new_sensor_ref = new_sensor_ref * new_ref_transform_offset;
 
   m_ft_sensor_transform = new_sensor_ref.Inverse() * sensor_ref;
 }

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -88,7 +88,7 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Make sure sensor wrenches are interpreted correctly
-  setFtSensorReferenceFrame(Base::m_end_effector_link);
+  setFtSensorReferenceFrame(Base::m_end_effector_link,m_end_effector_transform_offset);
 
   m_signal_taring_server = nh.advertiseService("signal_taring",&CartesianForceController<HardwareInterface>::signalTaringCallback,this);
   m_target_wrench_subscriber = nh.subscribe("target_wrench",2,&CartesianForceController<HardwareInterface>::targetWrenchCallback,this);
@@ -187,7 +187,7 @@ computeForceError()
   ctrl::Vector6D target_wrench;
   if (m_hand_frame_control) // Assume end-effector frame by convention
   {
-    target_wrench = Base::displayInBaseLink(m_target_wrench,Base::m_end_effector_link);
+    target_wrench = Base::displayInBaseLink(m_target_wrench,Base::m_end_effector_link,m_end_effector_transform_offset);
   }
   else // Default to robot base frame
   {

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -69,6 +69,15 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     return false;
   }
 
+  if(nh.hasParam("hand_frame_control"))
+  {
+    if (!nh.getParam("hand_frame_control",m_hand_frame_control))
+    {
+      ROS_ERROR_STREAM("Failed to load " << nh.getNamespace() + "/hand_frame_control" << " from parameter server");
+      return false;
+    }
+  }
+
   // Make sure sensor link is part of the robot chain
   if(!Base::robotChainContains(m_ft_sensor_ref_link))
   {


### PR DESCRIPTION
This is usefull when the end effector link is not part of the robot kinematic chain, e.g. when a gripper takes a screw driver. This parameter is optionnal and defaults to identity. Tested on a real robot (UR3).

Configuration exemple:
```yaml
my_cartesian_force_controller:
  type: "position_controllers/CartesianForceController"
  robot_base_link: "ur3_base_link"
  end_effector_link: "robotiq_2f140_tcp"
  ft_sensor_ref_link: "robotiq_ft300_frame_id"
  hand_frame_control: true # Indicate in which frame the target_wrench is given:
                           #     True = given in end_effector_link coordinates,
                           #     False = given in robot_base_link coordinates
  # Current PR
  end_effector_transform_offset:
    x: 0
    y: 0
    z: 0
    # Rotate -pi/2 wrt. the end_effector_link Y axis
    qx: 0
    qy: -0.7071068
    qz: 0
    qw: 0.7071068

  # Alternate 1
  end_effector_transform_offset:
    position: {x: 0, y: 0, z: 0}
    orientation: {qx: 0, qy: -0.7071068, qz: 0, qw: 0.7071068}
   
  # Alternate 2
  end_effector_transform_offset:
    [0, 0, 0, 0, -0.7071068, 0, 0.7071068]  # [x, y, z, qx, qy, qz, qw]
```