### PR TITLE
Add optionnal end effector transform offset for the cartesian force controller

### DIFF
--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
@@ -85,7 +85,7 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   }
 
   // Make sure sensor wrenches are interpreted correctly
-  ForceBase::setFtSensorReferenceFrame(m_compliance_ref_link);
+  ForceBase::setFtSensorReferenceFrame(m_compliance_ref_link, Base::m_identity_transform_kdl);
 
   // Connect dynamic reconfigure and overwrite the default values with values
   // on the parameter server. This is done automatically if parameters with

--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.hpp
@@ -126,6 +126,15 @@ update(const ros::Time& time, const ros::Duration& period)
   // Synchronize the internal model and the real robot
   Base::m_ik_solver->synchronizeJointPositions(Base::m_joint_handles);
 
+  // Update end-effector offset
+  Base::updateEndEffectorOffset();
+
+  // Reset FTS Reference frame when end effector offset has been updated
+  if(Base::m_end_effector_offset_updated)
+  {
+    ForceBase::setFtSensorReferenceFrame(Base::m_end_effector_link,Base::m_end_effector_offset);
+  }
+
   // Control the robot motion in such a way that the resulting net force
   // vanishes. This internal control needs some simulation time steps.
   for (int i = 0; i < Base::m_iterations; ++i)

--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -144,10 +144,12 @@ include_directories(
 add_library(${PROJECT_NAME}
   src/SpatialPDController.cpp
   src/PDController.cpp
+  src/PoseParameterHandle.cpp
   include/cartesian_controller_base/cartesian_controller_base.h
   include/cartesian_controller_base/cartesian_controller_base.hpp
   include/cartesian_controller_base/SpatialPDController.h
   include/cartesian_controller_base/PDController.h
+  include/cartesian_controller_base/PoseParameterHandle.h
   include/cartesian_controller_base/Utility.h
   src/IKSolver.cpp
   include/cartesian_controller_base/IKSolver.h

--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -109,6 +109,7 @@ generate_dynamic_reconfigure_options(
         cfg/PDGains.cfg
         cfg/DampedLeastSquaresSolver.cfg
         cfg/ForwardDynamicsSolver.cfg
+        cfg/SpatialPose.cfg
 )
 
 ###################################

--- a/cartesian_controller_base/cfg/SpatialPose.cfg
+++ b/cartesian_controller_base/cfg/SpatialPose.cfg
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+PACKAGE = "cartesian_controller_base"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+position = gen.add_group("Position")
+
+position.add("px", double_t, 0, "Position of a point in free space X axis", 0.0)
+position.add("py", double_t, 0, "Position of a point in free space Y axis", 0.0)
+position.add("pz", double_t, 0, "Position of a point in free space Z axis", 0.0)
+
+orientation = gen.add_group("Orientation")
+
+orientation.add("qx", double_t, 0, "Quaternion X parameter", 0.0, -1.0, 1.0)
+orientation.add("qy", double_t, 0, "Quaternion Y parameter", 0.0, -1.0, 1.0)
+orientation.add("qz", double_t, 0, "Quaternion Z parameter", 0.0, -1.0, 1.0)
+orientation.add("qw", double_t, 0, "Quaternion W parameter", 1.0, -1.0, 1.0)
+
+exit(gen.generate(PACKAGE, "cartesian_controller_base", "SpatialPose"))

--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -157,8 +157,7 @@ class IKSolver
      * Call this periodically to update the internal simulation's forward
      * kinematics.
      */
-    void updateKinematics();
-
+    void updateKinematics(const KDL::Frame& offset);
   protected:
 
     /**

--- a/cartesian_controller_base/include/cartesian_controller_base/PoseParameterHandle.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/PoseParameterHandle.h
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+
+//-----------------------------------------------------------------------------
+/*!\file    PoseParameterHandle.h
+ *
+ * \author  Captain Yoshi <captain.yoshisaur@gmail.com>
+ * \date    2023/12/17
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#ifndef POSE_PARAMETER_HANDLE_H_INCLUDED
+#define POSE_PARAMETER_HANDLE_H_INCLUDED
+
+// STD
+#include <atomic>
+
+// ROS
+#include <ros/ros.h>
+
+// ros_control
+#include <realtime_tools/realtime_buffer.h>
+#include <realtime_tools/realtime_box.h>
+
+// KDL
+#include <kdl/frames.hpp>
+
+// Dynamic reconfigure
+#include <dynamic_reconfigure/server.h>
+#include <cartesian_controller_base/SpatialPoseConfig.h>
+
+namespace cartesian_controller_base
+{
+
+/**
+ * @brief A pose parameter getter utility
+ *
+ * Motivation for this custom implementation:
+ *
+ *  - Retrieve the pose parameter from dynamic reconfigure
+ *
+ *  - Check if the parameter has been updated atomically (atomically)
+ */
+class PoseParameterHandle
+{
+  public:
+    PoseParameterHandle();
+    PoseParameterHandle(const PoseParameterHandle& other); ///< RealtimeBuffer needs special treatment
+    ~PoseParameterHandle();
+
+    void init(const std::string& name_space);
+
+    bool has_new_pose();
+
+    KDL::Frame get_pose();
+
+  private:
+    std::atomic<bool> m_pose_updated{false};
+
+    realtime_tools::RealtimeBuffer<KDL::Frame> m_transform_kdl;
+
+    // Dynamic reconfigure
+    typedef cartesian_controller_base::SpatialPoseConfig Config;
+    void dynamicReconfigureCallback(Config& config, uint32_t level);
+
+    std::shared_ptr<dynamic_reconfigure::Server<Config> > m_dyn_conf_server;
+    dynamic_reconfigure::Server<Config>::CallbackType m_callback_type;
+
+};
+
+}
+
+#endif

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -96,6 +96,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
 
     virtual void starting(const ros::Time& time);
 
+    static const KDL::Frame identity_transform_kdl;
   protected:
     /**
      * @brief Write joint control commands to the real hardware
@@ -123,7 +124,7 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @return The quantity in the robot base frame
      */
-    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset=identity_transform_kdl);
 
     /**
      * @brief Display the given tensor in the robot base frame

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -122,20 +122,14 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @param vector The quantity to transform
      * @param from The reference frame where the quantity was formulated
+     * @param from_offset Optionnal offset
      *
      * @return The quantity in the robot base frame
      */
-    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset=identity_transform_kdl);
-
-    /**
-     * @brief Display the given vector in the given robot base link
-     *
-     * @param vector The quantity to transform
-     * @param from The reference frame where the quantity was formulated
-     *
-     * @return The quantity in the robot base frame
-     */
-    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from, const KDL::Frame& from_offset=identity_transform_kdl);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset);
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from, const KDL::Frame& from_offset);
 
     /**
      * @brief Display the given tensor in the robot base frame
@@ -158,20 +152,10 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @return The quantity in the new frame
      */
-    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset = identity_transform_kdl);
-
-    /**
-     * @brief Display a given vector in a new reference frame
-     *
-     * The vector is assumed to be given in the robot base frame.
-     *
-     * @param vector The quantity to transform
-     * @param to The reference frame in which to formulate the quantity
-     * @param to_offset Optionnal offset
-     *
-     * @return The quantity in the new frame
-     */
-    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to, const KDL::Frame& to_offset = identity_transform_kdl);
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to);
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset);
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to, const KDL::Frame& to_offset);
 
     /**
      * @brief Check if specified links are part of the robot chain

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -57,6 +57,7 @@
 
 // Project
 #include <cartesian_controller_base/IKSolver.h>
+#include <cartesian_controller_base/PoseParameterHandle.h>
 #include <cartesian_controller_base/SpatialPDController.h>
 #include <cartesian_controller_base/Utility.h>
 
@@ -184,6 +185,14 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
     std::vector<hardware_interface::JointHandle>      m_joint_handles;
 
     /**
+     * Allow users to specify a transform offset from the end-effector frame.
+     */
+    void updateEndEffectorOffset();
+
+    KDL::Frame m_end_effector_offset;
+    std::atomic<bool> m_end_effector_offset_updated = false;
+
+    /**
      * Whether or not to publish the controller's current end-effector pose and
      * twist.
      */
@@ -209,6 +218,9 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
 
     // Against multi initialization in multi inheritance scenarios
     bool m_already_initialized;
+
+    // Handles end effector offset pose, configurable using dynamic reconfigure
+    PoseParameterHandle m_end_effector_offset_handle;
 
     // Dynamic reconfigure
     typedef cartesian_controller_base::CartesianControllerConfig ControllerConfig;

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -144,10 +144,11 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      *
      * @param vector The quantity to transform
      * @param to The reference frame in which to formulate the quantity
+     * @param to_offset Optionnal offset
      *
      * @return The quantity in the new frame
      */
-    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to);
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset = identity_transform_kdl);
 
     /**
      * @brief Check if specified links are part of the robot chain

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -128,6 +128,16 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
     ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset=identity_transform_kdl);
 
     /**
+     * @brief Display the given vector in the given robot base link
+     *
+     * @param vector The quantity to transform
+     * @param from The reference frame where the quantity was formulated
+     *
+     * @return The quantity in the robot base frame
+     */
+    ctrl::Vector6D displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from, const KDL::Frame& from_offset=identity_transform_kdl);
+
+    /**
      * @brief Display the given tensor in the robot base frame
      *
      * @param tensor The quantity to transform
@@ -149,6 +159,19 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
      * @return The quantity in the new frame
      */
     ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset = identity_transform_kdl);
+
+    /**
+     * @brief Display a given vector in a new reference frame
+     *
+     * The vector is assumed to be given in the robot base frame.
+     *
+     * @param vector The quantity to transform
+     * @param to The reference frame in which to formulate the quantity
+     * @param to_offset Optionnal offset
+     *
+     * @return The quantity in the new frame
+     */
+    ctrl::Vector6D displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to, const KDL::Frame& to_offset = identity_transform_kdl);
 
     /**
      * @brief Check if specified links are part of the robot chain

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -96,9 +96,10 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
     virtual bool init(HardwareInterface* hw, ros::NodeHandle& nh);
 
     virtual void starting(const ros::Time& time);
-
-    static const KDL::Frame identity_transform_kdl;
   protected:
+
+    const KDL::Frame m_identity_transform_kdl;
+
     /**
      * @brief Write joint control commands to the real hardware
      *

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -297,6 +297,20 @@ computeJointControlCmds(const ctrl::Vector6D& error, const ros::Duration& period
 
 template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
+{
+  return displayInBaseLink(vector, from, m_identity_transform_kdl);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from)
+{
+  return displayInBaseLink(vector, from, m_identity_transform_kdl);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
 displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset)
 {
   KDL::Frame transform_kdl;
@@ -367,6 +381,20 @@ displayInBaseLink(const ctrl::Matrix6D& tensor, const std::string& from)
   tmp.bottomRightCorner<3,3>() = R * tensor.bottomRightCorner<3,3>() * R.transpose();
 
   return tmp;
+}
+
+  template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInTipLink(const ctrl::Vector6D& vector, const std::string& to)
+{
+  return displayInTipLink(vector, to, m_identity_transform_kdl);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to)
+{
+  return displayInTipLink(vector, to, m_identity_transform_kdl);
 }
 
 template <class HardwareInterface>

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -274,7 +274,7 @@ computeJointControlCmds(const ctrl::Vector6D& error, const ros::Duration& period
 
 template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
-displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
+displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset)
 {
   // Adjust format
   KDL::Wrench wrench_kdl;
@@ -288,6 +288,9 @@ displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from)
       m_ik_solver->getPositions(),
       transform_kdl,
       from);
+
+  // Apply offset
+  transform_kdl = transform_kdl * from_offset;
 
   // Rotate into new reference frame
   wrench_kdl = transform_kdl.M * wrench_kdl;

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -299,6 +299,19 @@ template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
 displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const KDL::Frame& from_offset)
 {
+  KDL::Frame transform_kdl;
+  m_forward_kinematics_solver->JntToCart(
+      m_ik_solver->getPositions(),
+      transform_kdl,
+      from);
+
+  return displayInBaseLink(vector, transform_kdl, from_offset);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInBaseLink(const ctrl::Vector6D& vector, const KDL::Frame& from, const KDL::Frame& from_offset)
+{
   // Adjust format
   KDL::Wrench wrench_kdl;
   for (int i = 0; i < 6; ++i)
@@ -306,14 +319,9 @@ displayInBaseLink(const ctrl::Vector6D& vector, const std::string& from, const K
     wrench_kdl(i) = vector[i];
   }
 
-  KDL::Frame transform_kdl;
-  m_forward_kinematics_solver->JntToCart(
-      m_ik_solver->getPositions(),
-      transform_kdl,
-      from);
-
   // Apply offset
-  transform_kdl = transform_kdl * from_offset;
+  KDL::Frame transform_kdl;
+  transform_kdl = from * from_offset;
 
   // Rotate into new reference frame
   wrench_kdl = transform_kdl.M * wrench_kdl;
@@ -365,6 +373,19 @@ template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
 displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset)
 {
+  KDL::Frame transform_kdl;
+  m_forward_kinematics_solver->JntToCart(
+      m_ik_solver->getPositions(),
+      transform_kdl,
+      to);
+
+  return displayInTipLink(vector, transform_kdl, to_offset);
+}
+
+template <class HardwareInterface>
+ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
+displayInTipLink(const ctrl::Vector6D& vector, const KDL::Frame& to, const KDL::Frame& to_offset)
+{
   // Adjust format
   KDL::Wrench wrench_kdl;
   for (int i = 0; i < 6; ++i)
@@ -372,14 +393,9 @@ displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL:
     wrench_kdl(i) = vector[i];
   }
 
-  KDL::Frame transform_kdl;
-  m_forward_kinematics_solver->JntToCart(
-      m_ik_solver->getPositions(),
-      transform_kdl,
-      to);
-
   // Apply offset
-  transform_kdl = transform_kdl * to_offset;
+  KDL::Frame transform_kdl;
+  transform_kdl = to * to_offset;
 
   // Rotate into new reference frame
   wrench_kdl = transform_kdl.M.Inverse() * wrench_kdl;

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -222,12 +222,12 @@ template <class HardwareInterface>
 void CartesianControllerBase<HardwareInterface>::
 starting(const ros::Time& time)
 {
+  // Update end effector offset pose
+  updateEndEffectorOffset();
+
   // Copy joint state to internal simulation
   m_ik_solver->setStartState(m_joint_handles);
-  m_ik_solver->updateKinematics();
-
-  // update end effector offset pose
-  updateEndEffectorOffset();
+  m_ik_solver->updateKinematics(m_end_effector_offset);
 
   // Provide safe command buffers with starting where we are
   computeJointControlCmds(ctrl::Vector6D::Zero(), ros::Duration(0));
@@ -292,7 +292,7 @@ computeJointControlCmds(const ctrl::Vector6D& error, const ros::Duration& period
       period,
       m_cartesian_input);
 
-  m_ik_solver->updateKinematics();
+  m_ik_solver->updateKinematics(m_end_effector_offset);
 }
 
 template <class HardwareInterface>

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -145,6 +145,12 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
     throw std::runtime_error(error);
   }
 
+  // Initialize end effector offset
+  m_end_effector_offset = KDL::Frame::Identity();
+
+  std::string spatial_pose_config = nh.getNamespace() + "/end_effector_offset";
+  m_end_effector_offset_handle.init(spatial_pose_config);
+
   // Parse joint limits
   KDL::JntArray upper_pos_limits(m_joint_names.size());
   KDL::JntArray lower_pos_limits(m_joint_names.size());
@@ -220,6 +226,9 @@ starting(const ros::Time& time)
   m_ik_solver->setStartState(m_joint_handles);
   m_ik_solver->updateKinematics();
 
+  // update end effector offset pose
+  updateEndEffectorOffset();
+
   // Provide safe command buffers with starting where we are
   computeJointControlCmds(ctrl::Vector6D::Zero(), ros::Duration(0));
   writeJointControlCmds();
@@ -254,6 +263,20 @@ writeJointControlCmds()
   for (size_t i = 0; i < m_joint_handles.size(); ++i)
   {
     m_joint_handles[i].setCommand(m_simulated_joint_motion.velocities[i]);
+  }
+}
+
+template <class HardwareInterface>
+void CartesianControllerBase<HardwareInterface>::
+updateEndEffectorOffset()
+{
+  if(m_end_effector_offset_handle.has_new_pose())
+  {
+    m_end_effector_offset_updated = true;
+    m_end_effector_offset = m_end_effector_offset_handle.get_pose();
+  }
+  else{
+    m_end_effector_offset_updated = false;
   }
 }
 

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.hpp
@@ -363,7 +363,7 @@ displayInBaseLink(const ctrl::Matrix6D& tensor, const std::string& from)
 
 template <class HardwareInterface>
 ctrl::Vector6D CartesianControllerBase<HardwareInterface>::
-displayInTipLink(const ctrl::Vector6D& vector, const std::string& to)
+displayInTipLink(const ctrl::Vector6D& vector, const std::string& to, const KDL::Frame& to_offset)
 {
   // Adjust format
   KDL::Wrench wrench_kdl;
@@ -377,6 +377,9 @@ displayInTipLink(const ctrl::Vector6D& vector, const std::string& to)
       m_ik_solver->getPositions(),
       transform_kdl,
       to);
+
+  // Apply offset
+  transform_kdl = transform_kdl * to_offset;
 
   // Rotate into new reference frame
   wrench_kdl = transform_kdl.M.Inverse() * wrench_kdl;

--- a/cartesian_controller_base/src/IKSolver.cpp
+++ b/cartesian_controller_base/src/IKSolver.cpp
@@ -128,14 +128,17 @@ namespace cartesian_controller_base{
     return true;
   }
 
-  void IKSolver::updateKinematics()
+  void IKSolver::updateKinematics(const KDL::Frame& offset)
   {
     // Pose w. r. t. base
     m_fk_pos_solver->JntToCart(m_current_positions,m_end_effector_pose);
+    m_end_effector_pose = m_end_effector_pose * offset;
 
     // Absolute velocity w. r. t. base
     KDL::FrameVel vel;
     m_fk_vel_solver->JntToCart(KDL::JntArrayVel(m_current_positions,m_current_velocities),vel);
+    vel = vel * offset;
+
     m_end_effector_vel[0] = vel.deriv().vel.x();
     m_end_effector_vel[1] = vel.deriv().vel.y();
     m_end_effector_vel[2] = vel.deriv().vel.z();

--- a/cartesian_controller_base/src/PoseParameterHandle.cpp
+++ b/cartesian_controller_base/src/PoseParameterHandle.cpp
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2019 FZI Research Center for Information Technology
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////
+
+
+//-----------------------------------------------------------------------------
+/*!\file    PoseParameterHandle.cpp
+ *
+ * \author  Captain Yoshi <captain.yoshisaur@gmail.com>
+ * \date    2023/12/17
+ *
+ */
+//-----------------------------------------------------------------------------
+
+#include <cartesian_controller_base/PoseParameterHandle.h>
+
+namespace cartesian_controller_base
+{
+
+PoseParameterHandle::PoseParameterHandle()
+{
+}
+
+PoseParameterHandle::PoseParameterHandle(const PoseParameterHandle& other)
+  : m_dyn_conf_server(other.m_dyn_conf_server)
+{
+  // Copy constructor would bind non-const ref
+  // to const, so use copy assignment operator.
+  m_transform_kdl = other.m_transform_kdl;
+}
+
+PoseParameterHandle::~PoseParameterHandle()
+{
+}
+
+
+void PoseParameterHandle::init(const std::string& name_space)
+{
+  // Connect dynamic reconfigure and overwrite the default values with values
+  // on the parameter server. This is done automatically if parameters with
+  // the according names exist.
+  m_callback_type = std::bind(
+    &PoseParameterHandle::dynamicReconfigureCallback, this, std::placeholders::_1, std::placeholders::_2);
+
+  m_dyn_conf_server.reset(
+      new dynamic_reconfigure::Server<SpatialPoseConfig>(
+        ros::NodeHandle(name_space)));
+  m_dyn_conf_server->setCallback(m_callback_type);
+
+}
+
+bool PoseParameterHandle::has_new_pose()
+{
+  // Enables a compare exchange atomatically, e.g. we are sure to not miss
+  // any new pose updates (not the pose msg but the availability of the pose)
+  //
+  // Per C++11 § 29.6.5:
+  // A consequence of spurious failure is that nearly all uses of weak compare-and-exchange will be in a loop.
+  //
+  // We don't need a loop because on a spurious failure:
+  //   1) Missing an update on a couple of cyclesWe will eventually succeed on the next call (this method must be used in the ros_control::update)
+  //   2) The code does nothing harmfull on a failure
+  //
+  bool expected = true;
+  if(std::atomic_compare_exchange_weak(&m_pose_updated,&expected,false))
+  {
+    return true;
+  }
+  else{
+    // WARNING Might be a spurious failure. Be carefull what you add here...
+    return false;
+  }
+}
+
+
+KDL::Frame PoseParameterHandle::get_pose()
+{
+  return *m_transform_kdl.readFromRT();
+}
+
+void PoseParameterHandle::dynamicReconfigureCallback(Config& config, uint32_t level)
+{
+  m_transform_kdl.writeFromNonRT(KDL::Frame(KDL::Rotation::Quaternion(config.qx, config.qy, config.qz, config.qw),
+                                 KDL::Vector(config.px, config.py, config.pz)));
+
+  m_pose_updated = true;
+}
+
+}

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -101,7 +101,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
      */
     ctrl::Vector6D        computeForceError();
     std::string           m_new_ft_sensor_ref;
-    void setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_offset=Base::identity_transform_kdl);
+    void setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_offset);
 
   private:
     ctrl::Vector6D        compensateGravity();

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -101,7 +101,7 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
      */
     ctrl::Vector6D        computeForceError();
     std::string           m_new_ft_sensor_ref;
-    void setFtSensorReferenceFrame(const std::string& new_ref);
+    void setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_offset=Base::identity_transform_kdl);
 
   private:
     ctrl::Vector6D        compensateGravity();

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -193,7 +193,7 @@ computeForceError()
 
 template <class HardwareInterface>
 void CartesianForceController<HardwareInterface>::
-setFtSensorReferenceFrame(const std::string& new_ref)
+setFtSensorReferenceFrame(const std::string& new_ref, const KDL::Frame& new_ref_offset)
 {
   // Compute static transform from the force torque sensor to the new reference
   // frame of interest.
@@ -214,6 +214,8 @@ setFtSensorReferenceFrame(const std::string& new_ref)
       jnts,
       new_sensor_ref,
       m_new_ft_sensor_ref);
+
+  new_sensor_ref = new_sensor_ref * new_ref_offset;
 
   m_ft_sensor_transform = new_sensor_ref.Inverse() * sensor_ref;
 }


### PR DESCRIPTION
Ability to add an offset to the end effector link. Usefull when the end effector link is not part of the robot kinematic chain, e.g. when a gripper takes a screw driver. Tested on a real UR3 :)

Adds a generic `SpatialPose` config and `PoseParameterHandle` for handling updates of a pose through the dynamic reconfigure server. A getter to retrieve the pose and an atomic query method to see if a new pose is available.

Use the `PoseParameterHandle` in the cartesian force controller. Enables the offset to bet set at runtime at the start of the loop to avoid having a potential different offset for the FT sensor reference frame and the target wrench.

Setting the pose from within RQT is not recommanded, because we can only adjust one parameter at a time. But you can use the dynamic reconfigure client to set the pose offset parameters in one shot. Can also be configured in the yaml config.

![image](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/assets/32679594/9ac72d6d-d6f4-4fea-8183-c3515fc25881)

An example of the optionnal offset parameter in the config:
```yaml
my_cartesian_force_controller:
  type: "position_controllers/CartesianForceController"
  robot_base_link: "ur3_base_link"
  end_effector_link: "robotiq_2f140_tcp"
  ft_sensor_ref_link: "robotiq_ft300_frame_id"
  hand_frame_control: true

  end_effector_transform_offset:
    px: 0
    py: 0
    pz: 0
    # Rotate -pi/2 wrt. the end_effector_link Y axis
    qx: 0
    qy: -0.7071068
    qz: 0
    qw: 0.7071068
```

Drawback: Adds 1 matrix multiplication when `m_hand_frame_control = False`, otherwise 2 matrix multiplications. Also retriggers the `setFtSensorReferenceFrame` on each new pose.

---
It's totaly fine if you don't want this feature as it adds some overhead to the controller.