### PR TITLE
Use MuJoCo 3.0.0 for the simulation

### DIFF
--- a/.github/script/install_mujoco.sh
+++ b/.github/script/install_mujoco.sh
@@ -1,5 +1,5 @@
 #/usr/bin/bash
 cd $HOME
 apt install wget
-wget https://github.com/deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
-tar -xf mujoco-2.1.1-linux-x86_64.tar.gz
+wget https://github.com/deepmind/mujoco/releases/download/3.0.0/mujoco-3.0.0-linux-x86_64.tar.gz
+tar -xf mujoco-3.0.0-linux-x86_64.tar.gz

--- a/cartesian_controller_simulation/CMakeLists.txt
+++ b/cartesian_controller_simulation/CMakeLists.txt
@@ -23,12 +23,12 @@ find_package(rclcpp REQUIRED)
 # Mujoco comes as a pre-built library package.
 # Extract this package somewhere and point CMake towards it during the build process.
 if(NOT DEFINED MUJOCO_DIR)
-        set(MUJOCO_DIR "$ENV{HOME}/mujoco-2.1.1") # CI setting
+        set(MUJOCO_DIR "$ENV{HOME}/mujoco-3.0.0") # CI setting
         message(WARNING "MUJOCO_DIR not specified. Using default ${MUJOCO_DIR}")
 endif()
 set(MUJOCO_INCLUDE_DIRS ${MUJOCO_DIR}/include)
 set(MUJOCO_LIBRARIES
-        ${MUJOCO_DIR}/lib/libmujoco_nogl.so
+        ${MUJOCO_DIR}/lib/libmujoco.so
 )
 
 # --------------------------------------------------------------------------------

--- a/cartesian_controller_simulation/README.md
+++ b/cartesian_controller_simulation/README.md
@@ -11,17 +11,17 @@ This gives us a strong environment to realistically test control and contact phe
 We use MuJoCo in [headless mode](https://mujoco.readthedocs.io/en/latest/programming.html?highlight=headless#using-opengl)
 and don't need OpenGL-related dependencies.
 
-1. Download MuJoCo's most recent [release](https://github.com/deepmind/mujoco/releases/) and extract that somewhere.
-It's a ready-to-use, pre-built library package, and we will just point to it during the build.
+1. Download MuJoCo's pre-built [library package](https://github.com/deepmind/mujoco/releases/) and extract that somewhere.
+It's ready-to-use and we will just point to it during the build.
    ```bash
    cd $HOME
-   wget https://github.com/deepmind/mujoco/releases/download/2.1.1/mujoco-2.1.1-linux-x86_64.tar.gz
-   tar -xf mujoco-2.1.1-linux-x86_64.tar.gz
+   wget https://github.com/deepmind/mujoco/releases/download/3.0.0/mujoco-3.0.0-linux-x86_64.tar.gz
+   tar -xf mujoco-3.0.0-linux-x86_64.tar.gz
    ```
 
 3. Switch to the *root* of your ROS2 workspace and build the package (*standalone*) with
    ```bash
-   colcon build --cmake-args "-DMUJOCO_DIR=$HOME/mujoco-2.1.1" --packages-select cartesian_controller_simulation
+   colcon build --cmake-args "-DMUJOCO_DIR=$HOME/mujoco-3.0.0" --packages-select cartesian_controller_simulation
    ```
 
 

--- a/cartesian_controller_simulation/include/cartesian_controller_simulation/mujoco_simulator.h
+++ b/cartesian_controller_simulation/include/cartesian_controller_simulation/mujoco_simulator.h
@@ -45,7 +45,7 @@
 #include <string>
 #include <vector>
 
-#include "mujoco.h"
+#include "mujoco/mujoco.h"
 
 namespace cartesian_controller_simulation
 {


### PR DESCRIPTION
MuJoCo now uses the conventional package layout for its includes.
This is hopefully more stable for upcoming MuJoCo releases.