### PR TITLE
Add optional pre/post chain segment to the default robot_chain

### DIFF
--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   controller_interface
   kdl_parser
+  geometry_msgs
   trajectory_msgs
   control_toolbox
   eigen_conversions
@@ -70,11 +71,9 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(DIRECTORY srv FILES
+  SetKinematicChainOffsets.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -84,10 +83,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs  # Or other packages containing msgs
-# )
+generate_messages(
+   DEPENDENCIES
+   geometry_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##
@@ -123,7 +122,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES cartesian_controller_base ik_solvers
-  CATKIN_DEPENDS roscpp controller_interface kdl_parser trajectory_msgs control_toolbox eigen_conversions dynamic_reconfigure pluginlib
+  CATKIN_DEPENDS roscpp controller_interface kdl_parser geometry_msgs trajectory_msgs control_toolbox eigen_conversions dynamic_reconfigure pluginlib
 #  DEPENDS system_lib
 )
 

--- a/cartesian_controller_base/CMakeLists.txt
+++ b/cartesian_controller_base/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(catkin REQUIRED COMPONENTS
   trajectory_msgs
   control_toolbox
   eigen_conversions
+  kdl_conversions
   dynamic_reconfigure
   pluginlib
 )
@@ -122,7 +123,7 @@ generate_dynamic_reconfigure_options(
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES cartesian_controller_base ik_solvers
-  CATKIN_DEPENDS roscpp controller_interface kdl_parser geometry_msgs trajectory_msgs control_toolbox eigen_conversions dynamic_reconfigure pluginlib
+  CATKIN_DEPENDS roscpp controller_interface kdl_parser geometry_msgs trajectory_msgs control_toolbox kdl_conversions eigen_conversions dynamic_reconfigure pluginlib
 #  DEPENDS system_lib
 )
 

--- a/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
@@ -102,6 +102,11 @@ class DampedLeastSquaresSolver : public IKSolver
               const KDL::JntArray& upper_pos_limits,
               const KDL::JntArray& lower_pos_limits);
 
+    /**
+     * @brief Update the robot kinematic chain of the solver
+     */
+    virtual bool updateChain(const KDL::Chain& chain);
+
   private:
     std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
     KDL::Jacobian m_jnt_jacobian;

--- a/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
@@ -123,6 +123,11 @@ class ForwardDynamicsSolver : public IKSolver
               const KDL::JntArray& upper_pos_limits,
               const KDL::JntArray& lower_pos_limits);
 
+    /**
+     * @brief Update the robot kinematic chain of the solver
+     */
+    bool updateChain(const KDL::Chain& chain);
+
   private:
 
     //! Build a generic robot model for control

--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -152,6 +152,11 @@ class IKSolver
                       const KDL::JntArray& lower_pos_limits);
 
     /**
+     * @brief Update the robot kinematic chain of the solver
+     */
+    virtual bool updateChain(const KDL::Chain& chain);
+
+    /**
      * @brief Update the robot kinematics of the solver
      *
      * Call this periodically to update the internal simulation's forward

--- a/cartesian_controller_base/include/cartesian_controller_base/JacobianTransposeSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/JacobianTransposeSolver.h
@@ -95,6 +95,11 @@ class JacobianTransposeSolver : public IKSolver
               const KDL::JntArray& upper_pos_limits,
               const KDL::JntArray& lower_pos_limits);
 
+    /**
+     * @brief Update the robot kinematic chain of the solver
+     */
+    virtual bool updateChain(const KDL::Chain& chain);
+
   private:
     std::shared_ptr<KDL::ChainJntToJacSolver> m_jnt_jacobian_solver;
     KDL::Jacobian m_jnt_jacobian;

--- a/cartesian_controller_base/include/cartesian_controller_base/SelectivelyDampedLeastSquaresSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/SelectivelyDampedLeastSquaresSolver.h
@@ -101,6 +101,11 @@ class SelectivelyDampedLeastSquaresSolver : public IKSolver
               const KDL::JntArray& upper_pos_limits,
               const KDL::JntArray& lower_pos_limits);
 
+    /**
+     * @brief Update the robot kinematic chain of the solver
+     */
+    bool updateChain(const KDL::Chain& chain);
+
   private:
     /**
      * @brief Helper function to clamp a column vector

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -59,6 +59,7 @@
 #include <cartesian_controller_base/IKSolver.h>
 #include <cartesian_controller_base/SpatialPDController.h>
 #include <cartesian_controller_base/Utility.h>
+#include <cartesian_controller_base/SetKinematicChainOffsets.h>
 
 // Dynamic reconfigure
 #include <dynamic_reconfigure/server.h>
@@ -200,6 +201,20 @@ class CartesianControllerBase : public controller_interface::Controller<Hardware
     void publishStateFeedback();
 
   private:
+    /**
+     * @brief Allow users to add a chain segment before and/or after the robot chain
+     *
+     * Before:
+     * Empty segment if frame_id is empty, otherwise consist of a fixed segment that will
+     * become the parent of the robot base link.
+     *
+     * After:
+     * Empty segment if frame_id is empty,otherwise consist of a fixed segment that will
+     * be attached to the end effector link.
+     */
+    bool signalChainOffsetsCallback(SetKinematicChainOffsets::Request& req, SetKinematicChainOffsets::Response& res);
+
+    ros::ServiceServer    m_signal_chain_offsets_server;
     std::vector<std::string>                          m_joint_names;
     trajectory_msgs::JointTrajectoryPoint             m_simulated_joint_motion;
     SpatialPDController                              m_spatial_controller;

--- a/cartesian_controller_base/package.xml
+++ b/cartesian_controller_base/package.xml
@@ -42,6 +42,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>kdl_parser</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>control_toolbox</build_depend>
   <build_depend>eigen_conversions</build_depend>
@@ -51,6 +52,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>controller_interface</run_depend>
   <run_depend>kdl_parser</run_depend>
+  <run_depend>geometry_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>control_toolbox</run_depend>
   <run_depend>eigen_conversions</run_depend>

--- a/cartesian_controller_base/package.xml
+++ b/cartesian_controller_base/package.xml
@@ -46,6 +46,7 @@
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>control_toolbox</build_depend>
   <build_depend>eigen_conversions</build_depend>
+  <build_depend>kdl_conversions</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>pluginlib</build_depend>
 
@@ -56,6 +57,7 @@
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>control_toolbox</run_depend>
   <run_depend>eigen_conversions</run_depend>
+  <run_depend>kdl_conversions</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>pluginlib</run_depend>
 

--- a/cartesian_controller_base/src/DampedLeastSquaresSolver.cpp
+++ b/cartesian_controller_base/src/DampedLeastSquaresSolver.cpp
@@ -125,8 +125,7 @@ namespace cartesian_controller_base{
   {
     IKSolver::init(nh, chain, upper_pos_limits, lower_pos_limits);
 
-    m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
-    m_jnt_jacobian.resize(m_number_joints);
+    updateChain(m_chain);
 
     // Connect dynamic reconfigure and overwrite the default values with values
     // on the parameter server. This is done automatically if parameters with
@@ -142,6 +141,17 @@ namespace cartesian_controller_base{
     m_dyn_conf_server->setCallback(m_callback_type);
     return true;
   }
+
+  bool DampedLeastSquaresSolver::updateChain(const KDL::Chain& chain)
+  {
+    IKSolver::updateChain(chain);
+
+    m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
+    m_jnt_jacobian.resize(m_number_joints);
+
+    return true;
+  }
+
 
     void DampedLeastSquaresSolver::dynamicReconfigureCallback(IKConfig& config, uint32_t level)
     {

--- a/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
+++ b/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
@@ -138,17 +138,8 @@ namespace cartesian_controller_base{
   {
     IKSolver::init(nh, chain, upper_pos_limits, lower_pos_limits);
 
-    if (!buildGenericModel())
-    {
-      ROS_ERROR("ForwardDynamicsSolver: Something went wrong in setting up the internal model.");
+    if(!updateChain(m_chain))
       return false;
-    }
-
-    // Forward dynamics
-    m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
-    m_jnt_space_inertia_solver.reset(new KDL::ChainDynParam(m_chain,KDL::Vector::Zero()));
-    m_jnt_jacobian.resize(m_number_joints);
-    m_jnt_space_inertia.resize(m_number_joints);
 
     // Connect dynamic reconfigure and overwrite the default values with values
     // on the parameter server. This is done automatically if parameters with
@@ -169,6 +160,26 @@ namespace cartesian_controller_base{
 
     return true;
   }
+
+  bool ForwardDynamicsSolver::updateChain(const KDL::Chain& chain)
+  {
+    IKSolver::updateChain(chain);
+
+    if (!buildGenericModel())
+    {
+      ROS_ERROR("ForwardDynamicsSolver: Something went wrong in setting up the internal model.");
+      return false;
+    }
+
+    // Forward dynamics
+    m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
+    m_jnt_space_inertia_solver.reset(new KDL::ChainDynParam(m_chain,KDL::Vector::Zero()));
+    m_jnt_jacobian.resize(m_number_joints);
+    m_jnt_space_inertia.resize(m_number_joints);
+
+    return true;
+  }
+
 
   bool ForwardDynamicsSolver::buildGenericModel()
   {

--- a/cartesian_controller_base/src/IKSolver.cpp
+++ b/cartesian_controller_base/src/IKSolver.cpp
@@ -111,6 +111,20 @@ namespace cartesian_controller_base{
                       const KDL::JntArray& lower_pos_limits)
   {
     // Initialize
+    IKSolver::updateChain(chain);
+    m_upper_pos_limits           = upper_pos_limits;
+    m_lower_pos_limits           = lower_pos_limits;
+
+    return true;
+  }
+
+  bool IKSolver::updateChain(const KDL::Chain& chain)
+  {
+    // Guard against multiple initialization
+    // Also fixes a segfault...
+    if(&chain == &m_chain)
+      return true;
+
     m_chain = chain;
     m_number_joints              = m_chain.getNrOfJoints();
     m_current_positions.data     = ctrl::VectorND::Zero(m_number_joints);
@@ -118,8 +132,6 @@ namespace cartesian_controller_base{
     m_current_accelerations.data = ctrl::VectorND::Zero(m_number_joints);
     m_last_positions.data        = ctrl::VectorND::Zero(m_number_joints);
     m_last_velocities.data       = ctrl::VectorND::Zero(m_number_joints);
-    m_upper_pos_limits           = upper_pos_limits;
-    m_lower_pos_limits           = lower_pos_limits;
 
     // Forward kinematics
     m_fk_pos_solver.reset(new KDL::ChainFkSolverPos_recursive(m_chain));

--- a/cartesian_controller_base/src/JacobianTransposeSolver.cpp
+++ b/cartesian_controller_base/src/JacobianTransposeSolver.cpp
@@ -116,6 +116,15 @@ namespace cartesian_controller_base{
   {
     IKSolver::init(nh, chain, upper_pos_limits, lower_pos_limits);
 
+    updateChain(m_chain);
+
+    return true;
+  }
+
+  bool JacobianTransposeSolver::updateChain(const KDL::Chain& chain)
+  {
+    IKSolver::updateChain(chain);
+
     m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
     m_jnt_jacobian.resize(m_number_joints);
 

--- a/cartesian_controller_base/src/SelectivelyDampedLeastSquaresSolver.cpp
+++ b/cartesian_controller_base/src/SelectivelyDampedLeastSquaresSolver.cpp
@@ -148,6 +148,15 @@ namespace cartesian_controller_base{
   {
     IKSolver::init(nh, chain, upper_pos_limits, lower_pos_limits);
 
+    updateChain(m_chain);
+
+    return true;
+  }
+
+  bool SelectivelyDampedLeastSquaresSolver::updateChain(const KDL::Chain& chain)
+  {
+    IKSolver::updateChain(chain);
+
     m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
     m_jnt_jacobian.resize(m_number_joints);
 

--- a/cartesian_controller_base/srv/SetKinematicChainOffsets.srv
+++ b/cartesian_controller_base/srv/SetKinematicChainOffsets.srv
@@ -1,0 +1,8 @@
+# Ability to add a chain before or after the robot chain (parsed by the URDF)
+
+# Removes the chain if the frame_id is empty. Otherwise, overwrites the previous chain.
+geometry_msgs/PoseStamped pre_robot_chain_offset    # Attached before the robot base link
+geometry_msgs/PoseStamped post_robot_chain_offset   # Attached after end effector link
+---
+bool success
+string message

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -103,6 +103,14 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
     std::string           m_new_ft_sensor_ref;
     void setFtSensorReferenceFrame(const std::string& new_ref);
 
+    /**
+     * @brief Publish the controller's wrenches (sensor, gravity, target and net force)
+     *
+     * The data are w.r.t. the specified robot base link.
+     */
+    void publishStateWrenchFeedback(realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>& rt_publisher,
+                                    ctrl::Vector6D& wrench);
+
   private:
     ctrl::Vector6D        compensateGravity();
 
@@ -136,6 +144,15 @@ class CartesianForceController : public virtual cartesian_controller_base::Carte
 
     std::shared_ptr<dynamic_reconfigure::Server<Config> > m_dyn_conf_server;
     dynamic_reconfigure::Server<Config>::CallbackType m_callback_type;
+
+    realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>
+      m_feedback_gravity_wrench_publisher;
+    realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>
+      m_feedback_sensor_wrench_publisher;
+    realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>
+      m_feedback_target_wrench_publisher;
+    realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>
+      m_feedback_net_force_wrench_publisher;
 };
 
 }

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.hpp
@@ -113,6 +113,23 @@ init(HardwareInterface* hw, ros::NodeHandle& nh)
   m_target_wrench.setZero();
   m_ft_sensor_wrench.setZero();
 
+  // Controller-internal state publishing
+  m_feedback_gravity_wrench_publisher =
+    std::make_shared<realtime_tools::RealtimePublisher<geometry_msgs::WrenchStamped> >(
+      nh, "current_gravity_wrench", 3);
+
+  m_feedback_sensor_wrench_publisher =
+    std::make_shared<realtime_tools::RealtimePublisher<geometry_msgs::WrenchStamped> >(
+      nh, "current_sensor_wrench", 3);
+
+  m_feedback_target_wrench_publisher =
+    std::make_shared<realtime_tools::RealtimePublisher<geometry_msgs::WrenchStamped> >(
+      nh, "current_target_wrench", 3);
+
+  m_feedback_net_force_wrench_publisher =
+    std::make_shared<realtime_tools::RealtimePublisher<geometry_msgs::WrenchStamped> >(
+      nh, "current_net_force_wrench", 3);
+
   // Connect dynamic reconfigure and overwrite the default values with values
   // on the parameter server. This is done automatically if parameters with
   // the according names exist.
@@ -185,10 +202,28 @@ computeForceError()
     target_wrench = m_target_wrench;
   }
 
+  ctrl::Vector6D sensor_wrench;
+  sensor_wrench = Base::displayInBaseLink(m_ft_sensor_wrench,m_new_ft_sensor_ref);
+
+  ctrl::Vector6D gravity_wrench;
+  gravity_wrench = compensateGravity();
+
   // Superimpose target wrench and sensor wrench in base frame
-  return Base::displayInBaseLink(m_ft_sensor_wrench,m_new_ft_sensor_ref)
+  ctrl::Vector6D net_force_wrench;
+  net_force_wrench = sensor_wrench
     + target_wrench
-    + compensateGravity();
+    + gravity_wrench;
+
+  // Publish wrench state feedback
+  if (Base::m_publish_state_feedback)
+  {
+    publishStateWrenchFeedback(m_feedback_sensor_wrench_publisher, sensor_wrench);
+    publishStateWrenchFeedback(m_feedback_target_wrench_publisher, target_wrench);
+    publishStateWrenchFeedback(m_feedback_gravity_wrench_publisher, gravity_wrench);
+    publishStateWrenchFeedback(m_feedback_net_force_wrench_publisher, net_force_wrench);
+  }
+
+  return net_force_wrench;
 }
 
 template <class HardwareInterface>
@@ -293,6 +328,25 @@ signalTaringCallback(std_srvs::Trigger::Request& req, std_srvs::Trigger::Respons
   res.message = "Got it.";
   res.success = true;
   return true;
+}
+
+template <class HardwareInterface>
+void CartesianForceController<HardwareInterface>::
+publishStateWrenchFeedback(realtime_tools::RealtimePublisherSharedPtr<geometry_msgs::WrenchStamped>& rt_publisher,
+                           ctrl::Vector6D& wrench)
+{
+  if (rt_publisher->trylock()){
+    rt_publisher->msg_.header.stamp = ros::Time::now();
+    rt_publisher->msg_.header.frame_id = Base::m_robot_base_link;
+    rt_publisher->msg_.wrench.force.x = wrench[0];
+    rt_publisher->msg_.wrench.force.y = wrench[1];
+    rt_publisher->msg_.wrench.force.z = wrench[2];
+    rt_publisher->msg_.wrench.torque.x = wrench[3];
+    rt_publisher->msg_.wrench.torque.y = wrench[4];
+    rt_publisher->msg_.wrench.torque.z = wrench[5];
+
+    rt_publisher->unlockAndPublish();
+  }
 }
 
 template <class HardwareInterface>


### PR DESCRIPTION
Allows to make every parameter's and computation wrt. a new robot base. This is handy if one wants to have everything computed wrt. a fixed hand frame. I needed a way to be in the hand frame, but also have the PD cartesian gains to also be in the hand frame.

Allows to set an optionnal offset to the end effector. E.g. Be able to reason about a screwdriver (no URDF link) grasped from a gripper.

Uses a ROS Service to update the pre/post segments as a `geometry_msgs/PoseStamped`. Just set the frame_id to apply the desired pre/post segments. An empty frame_id will remove the corresponding segment. 
```yaml
# Ability to add a chain before or after the robot chain (parsed by the URDF)

# Removes the chain if the frame_id is empty. Otherwise, overwrites the previous chain.
geometry_msgs/PoseStamped pre_robot_chain_offset    # Attached before the robot base link
geometry_msgs/PoseStamped post_robot_chain_offset   # Attached after end effector link
---
bool success
string message
```
This should only bet set when the controller is stopped.

**TODO**
- Update the feedback states with the correct frame_id.
- Only permit when the controller has not started ?
- Test with motion controller.
- Test with compliance controller.
- Document it.