### PR TITLE
Allow to set IKSolver parameters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,19 @@ repos:
 
   # Python
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: '88a4f9b2f48fc44b025a48fa6a8ac7cc89ef70e0'  # 7.0.0
     hooks:
     -   id: flake8
 
   - repo: https://github.com/psf/black.git
-    rev: 23.7.0
+    rev: '6fdf8a4af28071ed1d079c01122b34c5d587207a' # 24.2.0
     hooks:
     -   id: black
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: '9db9854e3041219b1eb619872a2dfaf58adfb20b'  # v1.9.0
+    hooks:
+    -   id: mypy
 
   # C++
   - repo: local

--- a/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/DampedLeastSquaresSolver.h
@@ -103,8 +103,7 @@ private:
   KDL::Jacobian m_jnt_jacobian;
 
   // Dynamic parameters
-  std::shared_ptr<rclcpp::Node> m_handle;  ///< handle for dynamic parameter interaction
-  const std::string m_params = "solver/damped_least_squares";  ///< namespace for parameter access
+  const std::string m_params = "solver.damped_least_squares";  ///< namespace for parameter access
   double m_alpha;                                              ///< damping coefficient
 };
 

--- a/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/ForwardDynamicsSolver.h
@@ -119,8 +119,7 @@ private:
   KDL::JntSpaceInertiaMatrix m_jnt_space_inertia;
 
   // Dynamic parameters
-  std::shared_ptr<rclcpp::Node> m_handle;  ///< handle for dynamic parameter interaction
-  const std::string m_params = "solver/forward_dynamics";  ///< namespace for parameter access
+  const std::string m_params = "solver.forward_dynamics";  ///< namespace for parameter access
 
   /**
      * Virtual link mass

--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -170,6 +170,25 @@ protected:
      */
   void applyJointLimits();
 
+  template <typename ParameterT>
+  auto auto_declare(const std::string & name, const ParameterT & default_value)
+  {
+    if (!m_handle->has_parameter(name))
+    {
+      return m_handle->declare_parameter<ParameterT>(name, default_value);
+    }
+    else
+    {
+      return m_handle->get_parameter(name).get_value<ParameterT>();
+    }
+  }
+
+#if defined CARTESIAN_CONTROLLERS_HUMBLE || defined CARTESIAN_CONTROLLERS_IRON
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> m_handle;
+#else
+  std::shared_ptr<rclcpp::Node> m_handle;
+#endif
+
   //! The underlying physical system
   KDL::Chain m_chain;
 

--- a/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/IKSolver.h
@@ -183,11 +183,7 @@ protected:
     }
   }
 
-#if defined CARTESIAN_CONTROLLERS_HUMBLE || defined CARTESIAN_CONTROLLERS_IRON
   std::shared_ptr<rclcpp_lifecycle::LifecycleNode> m_handle;
-#else
-  std::shared_ptr<rclcpp::Node> m_handle;
-#endif
 
   //! The underlying physical system
   KDL::Chain m_chain;

--- a/cartesian_controller_base/src/DampedLeastSquaresSolver.cpp
+++ b/cartesian_controller_base/src/DampedLeastSquaresSolver.cpp
@@ -79,7 +79,7 @@ trajectory_msgs::msg::JointTrajectoryPoint DampedLeastSquaresSolver::getJointCon
   // \f$ \dot{q} = ( J^T J + \alpha^2 I )^{-1} J^T f \f$
   ctrl::MatrixND identity;
   identity.setIdentity(m_number_joints, m_number_joints);
-  m_handle->get_parameter(m_params + "/alpha", m_alpha);
+  m_handle->get_parameter(m_params + ".alpha", m_alpha);
 
   m_current_velocities.data =
     (m_jnt_jacobian.data.transpose() * m_jnt_jacobian.data + m_alpha * m_alpha * identity)
@@ -122,7 +122,7 @@ bool DampedLeastSquaresSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleN
   m_jnt_jacobian_solver.reset(new KDL::ChainJntToJacSolver(m_chain));
   m_jnt_jacobian.resize(m_number_joints);
 
-  nh->declare_parameter<double>(m_params + "/alpha", 1.0);
+  auto_declare(m_params + ".alpha", 1.0);
 
   return true;
 }

--- a/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
+++ b/cartesian_controller_base/src/ForwardDynamicsSolver.cpp
@@ -136,7 +136,7 @@ bool ForwardDynamicsSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode
   m_jnt_space_inertia.resize(m_number_joints);
 
   // Set the initial value if provided at runtime, else use default value.
-  m_min = nh->declare_parameter<double>(m_params + "/link_mass", 0.1);
+  m_min = auto_declare(m_params + ".link_mass", 0.1);
 
   RCLCPP_INFO(nh->get_logger(), "Forward dynamics solver initialized");
   RCLCPP_INFO(nh->get_logger(), "Forward dynamics solver has control over %i joints",

--- a/cartesian_controller_base/src/IKSolver.cpp
+++ b/cartesian_controller_base/src/IKSolver.cpp
@@ -102,9 +102,8 @@ void IKSolver::synchronizeJointPositions(
   }
 }
 
-bool IKSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> nh,
-                    const KDL::Chain & chain, const KDL::JntArray & upper_pos_limits,
-                    const KDL::JntArray & lower_pos_limits)
+bool IKSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> nh, const KDL::Chain & chain,
+                    const KDL::JntArray & upper_pos_limits, const KDL::JntArray & lower_pos_limits)
 {
   // Initialize
   m_handle = nh;

--- a/cartesian_controller_base/src/IKSolver.cpp
+++ b/cartesian_controller_base/src/IKSolver.cpp
@@ -102,11 +102,12 @@ void IKSolver::synchronizeJointPositions(
   }
 }
 
-bool IKSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> /*nh*/,
+bool IKSolver::init(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> nh,
                     const KDL::Chain & chain, const KDL::JntArray & upper_pos_limits,
                     const KDL::JntArray & lower_pos_limits)
 {
   // Initialize
+  m_handle = nh;
   m_chain = chain;
   m_number_joints = m_chain.getNrOfJoints();
   m_current_positions.data = ctrl::VectorND::Zero(m_number_joints);

--- a/cartesian_controller_tests/integration_tests/integration_tests.py
+++ b/cartesian_controller_tests/integration_tests/integration_tests.py
@@ -272,11 +272,15 @@ class IntegrationTest(unittest.TestCase):
         req = SetParameters.Request()
         req.parameters = params
         future = client.call_async(req)
-        rclpy.spin_until_future_complete(self.node, future)
+        rclpy.spin_until_future_complete(
+            self.node, future  # type: ignore[attr-defined]
+        )
 
     def get_parameters(self, client: Client, names: list[str]) -> Any:
         req = GetParameters.Request()
         req.names = names
         future = client.call_async(req)
-        rclpy.spin_until_future_complete(self.node, future)
+        rclpy.spin_until_future_complete(
+            self.node, future  # type: ignore[attr-defined]
+        )
         return future.result()


### PR DESCRIPTION
This PR aims to address the impossibility to set parameters of IK solvers from ROS2 yaml params file as suggested [here](https://github.com/fzi-forschungszentrum-informatik/cartesian_controllers/blob/dc803377752bcbc175004a549485ef011ec4a952/cartesian_controller_base/src/ForwardDynamicsSolver.cpp#L64).

To avoid params redeclarations an `auto_declare` protected method has been defined for the IKSolver base class

(fix similar to the one proposed in #129)

