### PR TITLE
feat: topic names as node parameters

### DIFF
--- a/cartesian_force_controller/src/cartesian_force_controller.cpp
+++ b/cartesian_force_controller/src/cartesian_force_controller.cpp
@@ -107,13 +107,18 @@ CartesianForceController::on_configure(const rclcpp_lifecycle::State & previous_
   // Make sure sensor wrenches are interpreted correctly
   setFtSensorReferenceFrame(Base::m_end_effector_link);
 
+  auto_declare<std::string>("target_wrench_topic",
+                            get_node()->get_name() + std::string("/target_wrench"));
+  auto_declare<std::string>("wrench_topic",
+                            get_node()->get_name() + std::string("/ft_sensor_wrench"));
+
   m_target_wrench_subscriber = get_node()->create_subscription<geometry_msgs::msg::WrenchStamped>(
-    get_node()->get_name() + std::string("/target_wrench"), 10,
+    get_node()->get_parameter("target_wrench_topic").as_string(), 10,
     std::bind(&CartesianForceController::targetWrenchCallback, this, std::placeholders::_1));
 
   m_ft_sensor_wrench_subscriber =
     get_node()->create_subscription<geometry_msgs::msg::WrenchStamped>(
-      get_node()->get_name() + std::string("/ft_sensor_wrench"), 10,
+      get_node()->get_parameter("wrench_topic").as_string(), 10,
       std::bind(&CartesianForceController::ftSensorWrenchCallback, this, std::placeholders::_1));
 
   m_target_wrench.setZero();

--- a/cartesian_motion_controller/src/cartesian_motion_controller.cpp
+++ b/cartesian_motion_controller/src/cartesian_motion_controller.cpp
@@ -87,8 +87,10 @@ CartesianMotionController::on_configure(const rclcpp_lifecycle::State & previous
     return ret;
   }
 
+  auto_declare<std::string>("target_frame_topic",
+                            get_node()->get_name() + std::string("/target_frame"));
   m_target_frame_subscr = get_node()->create_subscription<geometry_msgs::msg::PoseStamped>(
-    get_node()->get_name() + std::string("/target_frame"), 3,
+    get_node()->get_parameter("target_frame_topic").as_string(), 3,
     std::bind(&CartesianMotionController::targetFrameCallback, this, std::placeholders::_1));
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;


### PR DESCRIPTION
There might be situations in which the launch file in which the controller_manager node is started is not directly accessible thus making impossible for the user to define topic names for the controllers (as far as I understood it must be done via remappings on the node but correct me if I am wrong).

This PR defines and expose parameters for each topic name so that they can configured by means of the `controllers.yaml` file. Note that, default values of those params still matches the original one so, if not specified by the user, the original behavior is preserved.