### PR TITLE
added controller chaining to cartesian_controllers

### DIFF
--- a/cartesian_compliance_controller/cartesian_compliance_controller_plugin.xml
+++ b/cartesian_compliance_controller/cartesian_compliance_controller_plugin.xml
@@ -2,7 +2,7 @@
 
   <class name="cartesian_compliance_controller/CartesianComplianceController"
          type="cartesian_compliance_controller::CartesianComplianceController"
-         base_class_type="controller_interface::ControllerInterface">
+         base_class_type="controller_interface::ChainableControllerInterface">
     <description>
       Steer your robot's end-effector with Cartesian poses and force-torque vectors.
       It's ideal for realizing in-contact motion with force profiles.

--- a/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.h
+++ b/cartesian_compliance_controller/include/cartesian_compliance_controller/cartesian_compliance_controller.h
@@ -45,7 +45,7 @@
 #include <cartesian_force_controller/cartesian_force_controller.h>
 #include <cartesian_motion_controller/cartesian_motion_controller.h>
 
-#include <controller_interface/controller_interface.hpp>
+#include <controller_interface/chainable_controller_interface.hpp>
 
 namespace cartesian_compliance_controller
 {
@@ -86,8 +86,10 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & previous_state) override;
 
-  controller_interface::return_type update(const rclcpp::Time & time,
+  controller_interface::return_type update_and_write_commands(const rclcpp::Time & time,
                                            const rclcpp::Duration & period) override;
+
+  controller_interface::return_type update_reference_from_subscribers() override;
 
   using Base = cartesian_controller_base::CartesianControllerBase;
   using MotionBase = cartesian_motion_controller::CartesianMotionController;
@@ -100,6 +102,9 @@ private:
      * @return The remaining error wrench, given in robot base frame
      */
   ctrl::Vector6D computeComplianceError();
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::WrenchStamped::SharedPtr> rt_buffer_ptr_;
+
+  bool target_available_;
 
   ctrl::Matrix6D m_stiffness;
   std::string m_compliance_ref_link;

--- a/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
+++ b/cartesian_compliance_controller/src/cartesian_compliance_controller.cpp
@@ -40,7 +40,7 @@
 #include <cartesian_compliance_controller/cartesian_compliance_controller.h>
 
 #include "cartesian_controller_base/Utility.h"
-#include "controller_interface/controller_interface.hpp"
+#include "controller_interface/chainable_controller_interface.hpp"
 
 namespace cartesian_compliance_controller
 {
@@ -129,7 +129,7 @@ CartesianComplianceController::on_deactivate(const rclcpp_lifecycle::State & pre
   return TYPE::SUCCESS;
 }
 
-controller_interface::return_type CartesianComplianceController::update(
+controller_interface::return_type CartesianComplianceController::update_and_write_commands(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   // Synchronize the internal model and the real robot
@@ -137,6 +137,16 @@ controller_interface::return_type CartesianComplianceController::update(
 
   // Control the robot motion in such a way that the resulting net force
   // vanishes. This internal control needs some simulation time steps.
+
+  if (Base::chained_mode_available_)
+  {
+    ForceBase::m_target_wrench[0] = Base::reference_interfaces_[0];
+    ForceBase::m_target_wrench[1] = Base::reference_interfaces_[1];
+    ForceBase::m_target_wrench[2] = Base::reference_interfaces_[2];
+    ForceBase::m_target_wrench[3] = Base::reference_interfaces_[3];
+    ForceBase::m_target_wrench[4] = Base::reference_interfaces_[4];
+    ForceBase::m_target_wrench[5] = Base::reference_interfaces_[5];
+  }
   for (int i = 0; i < Base::m_iterations; ++i)
   {
     // The internal 'simulation time' is deliberately independent of the outer
@@ -179,10 +189,16 @@ ctrl::Vector6D CartesianComplianceController::computeComplianceError()
   return net_force;
 }
 
+controller_interface::return_type CartesianComplianceController::update_reference_from_subscribers()
+{
+  MotionBase::update_reference_from_subscribers();
+  ForceBase::update_reference_from_subscribers();
+  return controller_interface::return_type::OK;
+}
 }  // namespace cartesian_compliance_controller
 
 // Pluginlib
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(cartesian_compliance_controller::CartesianComplianceController,
-                       controller_interface::ControllerInterface)
+                       controller_interface::ChainableControllerInterface)

--- a/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
+++ b/cartesian_controller_base/include/cartesian_controller_base/cartesian_controller_base.h
@@ -45,7 +45,7 @@
 #include <cartesian_controller_base/Utility.h>
 #include <realtime_tools/realtime_publisher.h>
 
-#include <controller_interface/controller_interface.hpp>
+#include <controller_interface/chainable_controller_interface.hpp>
 #include <functional>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -75,7 +75,7 @@ namespace cartesian_controller_base
  * writeJointControlCmds.
  *
  */
-class CartesianControllerBase : public controller_interface::ControllerInterface
+class CartesianControllerBase : public controller_interface::ChainableControllerInterface
 {
 public:
   CartesianControllerBase();
@@ -86,6 +86,8 @@ public:
 
   virtual controller_interface::InterfaceConfiguration state_interface_configuration()
     const override;
+  
+  virtual std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
 
   virtual LifecycleNodeInterface::CallbackReturn on_init() override;
 
@@ -100,7 +102,8 @@ public:
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State & previous_state) override;
-
+  
+  bool on_set_chained_mode(bool chained_mode) override;
 protected:
   /**
      * @brief Write joint control commands to the real hardware
@@ -192,10 +195,19 @@ protected:
   std::string m_end_effector_link;
   std::string m_robot_base_link;
   int m_iterations;
+  mutable std::vector<std::string> reference_interface_names_;
 
   std::vector<std::reference_wrapper<hardware_interface::LoanedStateInterface>>
     m_joint_state_pos_handles;
+  
+  bool chained_mode_available_ = {false};
 
+  /**
+   * @brief controller_mode_ is to select the references interfaces to export. 
+   *
+   * @return true will export cartesian motion controller reference interfaces and false for cartesian force or compliance controller
+   */
+  bool controller_mode_ = {true};
 private:
   /**
      * @brief Stop joint motion when in velocity control

--- a/cartesian_controller_base/src/cartesian_controller_base.cpp
+++ b/cartesian_controller_base/src/cartesian_controller_base.cpp
@@ -46,7 +46,7 @@
 #include <kdl/tree.hpp>
 #include <kdl_parser/kdl_parser.hpp>
 
-#include "controller_interface/controller_interface.hpp"
+#include "controller_interface/chainable_controller_interface.hpp"
 #include "controller_interface/helpers.hpp"
 #include "geometry_msgs/msg/detail/pose_stamped__struct.hpp"
 #include "geometry_msgs/msg/detail/twist_stamped__struct.hpp"
@@ -101,6 +101,7 @@ CartesianControllerBase::on_init()
     auto_declare<int>("solver.iterations", 1);
     auto_declare<bool>("solver.publish_state_feedback", false);
     m_initialized = true;
+    chained_mode_available_ = false;
   }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
@@ -317,6 +318,10 @@ CartesianControllerBase::on_activate(const rclcpp_lifecycle::State & previous_st
   writeJointControlCmds();
 
   m_active = true;
+
+  std::fill(reference_interfaces_.begin(), reference_interfaces_.end(),
+            std::numeric_limits<double>::quiet_NaN());
+
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
@@ -334,6 +339,46 @@ CartesianControllerBase::on_shutdown(const rclcpp_lifecycle::State & previous_st
     m_active = false;
   }
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+bool CartesianControllerBase::on_set_chained_mode(bool /*chained_mode*/)
+{
+  chained_mode_available_ = true;
+  RCLCPP_INFO(get_node()->get_logger(), "in chained mode");
+  return true;
+}
+
+std::vector<hardware_interface::CommandInterface>
+CartesianControllerBase::on_export_reference_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> reference_interfaces;
+
+  std::vector<std::string> cartesian_interfaces_names_;
+  if (controller_mode_)
+  {
+    cartesian_interfaces_names_ = {
+      "position.x", "position.y", "position.z", "orientation.x", "orientation.y", "orientation.z", "orientation.w"};
+  }
+  else
+  {
+    cartesian_interfaces_names_ = {
+      "wrench.x", "wrench.y", "wrench.z", "torque.x", "torque.y", "torque.z"};
+  }
+
+  for (const auto & type : cartesian_interfaces_names_)
+  {
+    reference_interface_names_.push_back(type);
+  }
+
+  for (size_t i = 0; i < reference_interface_names_.size(); ++i)
+  {
+    reference_interfaces.push_back(hardware_interface::CommandInterface(
+      get_node()->get_name(), reference_interface_names_[i], &reference_interfaces_[i]));
+  }
+
+  reference_interfaces_.assign(reference_interface_names_.size(), 0.0);
+
+  return reference_interfaces;
 }
 
 void CartesianControllerBase::writeJointControlCmds()

--- a/cartesian_force_controller/cartesian_force_controller_plugin.xml
+++ b/cartesian_force_controller/cartesian_force_controller_plugin.xml
@@ -2,7 +2,7 @@
 
   <class name="cartesian_force_controller/CartesianForceController"
          type="cartesian_force_controller::CartesianForceController"
-         base_class_type="controller_interface::ControllerInterface">
+         base_class_type="controller_interface::ChainableControllerInterface">
     <description>
       Steer your robot's end-effector with forces and torques.
       It's ideal for teleoperation with contacts.

--- a/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
+++ b/cartesian_force_controller/include/cartesian_force_controller/cartesian_force_controller.h
@@ -43,7 +43,8 @@
 #include <cartesian_controller_base/ROS2VersionConfig.h>
 #include <cartesian_controller_base/cartesian_controller_base.h>
 
-#include <controller_interface/controller_interface.hpp>
+#include "realtime_tools/realtime_buffer.hpp"
+#include <controller_interface/chainable_controller_interface.hpp>
 
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 
@@ -87,8 +88,10 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & previous_state) override;
 
-  controller_interface::return_type update(const rclcpp::Time & time,
+  controller_interface::return_type update_and_write_commands(const rclcpp::Time & time,
                                            const rclcpp::Duration & period) override;
+
+  controller_interface::return_type update_reference_from_subscribers() override;
 
   using Base = cartesian_controller_base::CartesianControllerBase;
 
@@ -100,6 +103,7 @@ protected:
      */
   ctrl::Vector6D computeForceError();
   std::string m_new_ft_sensor_ref;
+  ctrl::Vector6D m_target_wrench;
   void setFtSensorReferenceFrame(const std::string & new_ref);
 
 private:
@@ -108,10 +112,11 @@ private:
 
   rclcpp::Subscription<geometry_msgs::msg::WrenchStamped>::SharedPtr m_target_wrench_subscriber;
   rclcpp::Subscription<geometry_msgs::msg::WrenchStamped>::SharedPtr m_ft_sensor_wrench_subscriber;
-  ctrl::Vector6D m_target_wrench;
+  
   ctrl::Vector6D m_ft_sensor_wrench;
   std::string m_ft_sensor_ref_link;
   KDL::Frame m_ft_sensor_transform;
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::WrenchStamped::SharedPtr> rt_buffer_ptr_;
 
   /**
      * Allow users to choose whether to specify their target wrenches in the
@@ -120,6 +125,7 @@ private:
      * intuitive for tele-manipulation.
      */
   bool m_hand_frame_control;
+  bool target_available_;
 };
 
 }  // namespace cartesian_force_controller

--- a/cartesian_force_controller/src/cartesian_force_controller.cpp
+++ b/cartesian_force_controller/src/cartesian_force_controller.cpp
@@ -42,7 +42,7 @@
 #include <cmath>
 
 #include "cartesian_controller_base/Utility.h"
-#include "controller_interface/controller_interface.hpp"
+#include "controller_interface/chainable_controller_interface.hpp"
 
 namespace cartesian_force_controller
 {
@@ -53,7 +53,8 @@ CartesianForceController::CartesianForceController()
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 CartesianForceController::on_init()
-{
+{ 
+  Base::controller_mode_ = false;
   const auto ret = Base::on_init();
   if (ret != rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
   {
@@ -74,6 +75,9 @@ CartesianForceController::on_configure(const rclcpp_lifecycle::State & previous_
   {
     return ret;
   }
+
+  target_available_ = false;
+  reference_interfaces_.resize(6, std::numeric_limits<double>::quiet_NaN());
 
   // Make sure sensor link is part of the robot chain
   m_ft_sensor_ref_link = get_node()->get_parameter("ft_sensor_ref_link").as_string();
@@ -118,9 +122,20 @@ CartesianForceController::on_deactivate(const rclcpp_lifecycle::State & previous
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type CartesianForceController::update(const rclcpp::Time & time,
+controller_interface::return_type CartesianForceController::update_and_write_commands(const rclcpp::Time & time,
                                                                    const rclcpp::Duration & period)
-{
+{ 
+  // check if chained mode available, in order to use references
+    if (Base::chained_mode_available_)
+  {
+    m_target_wrench[0] = Base::reference_interfaces_[0];
+    m_target_wrench[1] = Base::reference_interfaces_[1];
+    m_target_wrench[2] = Base::reference_interfaces_[2];
+    m_target_wrench[3] = Base::reference_interfaces_[3];
+    m_target_wrench[4] = Base::reference_interfaces_[4];
+    m_target_wrench[5] = Base::reference_interfaces_[5];
+  }
+  
   // Synchronize the internal model and the real robot
   Base::m_ik_solver->synchronizeJointPositions(Base::m_joint_state_pos_handles);
 
@@ -196,12 +211,31 @@ void CartesianForceController::targetWrenchCallback(
     return;
   }
 
-  m_target_wrench[0] = wrench->wrench.force.x;
-  m_target_wrench[1] = wrench->wrench.force.y;
-  m_target_wrench[2] = wrench->wrench.force.z;
-  m_target_wrench[3] = wrench->wrench.torque.x;
-  m_target_wrench[4] = wrench->wrench.torque.y;
-  m_target_wrench[5] = wrench->wrench.torque.z;
+  rt_buffer_ptr_.writeFromNonRT(wrench);
+  target_available_ = true;
+
+}
+
+controller_interface::return_type CartesianForceController::update_reference_from_subscribers()
+{
+  if (!this->isActive())
+  {
+    return controller_interface::return_type::OK;
+  }
+
+  if (target_available_)
+  {
+    auto target = rt_buffer_ptr_.readFromRT();
+
+    m_target_wrench[0] = (*target)->wrench.force.x;
+    m_target_wrench[1] = (*target)->wrench.force.y;
+    m_target_wrench[2] = (*target)->wrench.force.z;
+    m_target_wrench[3] = (*target)->wrench.torque.x;
+    m_target_wrench[4] = (*target)->wrench.torque.y;
+    m_target_wrench[5] = (*target)->wrench.torque.z;
+  }
+  
+  return controller_interface::return_type::OK;
 }
 
 void CartesianForceController::ftSensorWrenchCallback(
@@ -247,4 +281,4 @@ void CartesianForceController::ftSensorWrenchCallback(
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(cartesian_force_controller::CartesianForceController,
-                       controller_interface::ControllerInterface)
+                       controller_interface::ChainableControllerInterface)

--- a/cartesian_motion_controller/cartesian_motion_controller_plugin.xml
+++ b/cartesian_motion_controller/cartesian_motion_controller_plugin.xml
@@ -2,7 +2,7 @@
 
   <class name="cartesian_motion_controller/CartesianMotionController"
          type="cartesian_motion_controller::CartesianMotionController"
-         base_class_type="controller_interface::ControllerInterface">
+         base_class_type="controller_interface::ChainableControllerInterface">
     <description>
       Steer your robot's end-effector with poses in Cartesian space.
       Parameterize the controller between smoothness and exactness.

--- a/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.h
+++ b/cartesian_motion_controller/include/cartesian_motion_controller/cartesian_motion_controller.h
@@ -43,7 +43,8 @@
 #include <cartesian_controller_base/ROS2VersionConfig.h>
 #include <cartesian_controller_base/cartesian_controller_base.h>
 
-#include <controller_interface/controller_interface.hpp>
+#include "realtime_tools/realtime_buffer.hpp"
+#include <controller_interface/chainable_controller_interface.hpp>
 
 #include "geometry_msgs/msg/pose_stamped.hpp"
 
@@ -78,7 +79,7 @@ public:
   virtual ~CartesianMotionController() = default;
 
   virtual LifecycleNodeInterface::CallbackReturn on_init() override;
-
+  
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
     const rclcpp_lifecycle::State & previous_state) override;
 
@@ -88,8 +89,10 @@ public:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & previous_state) override;
 
-  controller_interface::return_type update(const rclcpp::Time & time,
+  controller_interface::return_type update_and_write_commands(const rclcpp::Time & time,
                                            const rclcpp::Duration & period) override;
+  controller_interface::return_type update_reference_from_subscribers() override;
+  
 
   using Base = cartesian_controller_base::CartesianControllerBase;
 
@@ -107,6 +110,10 @@ protected:
   ctrl::Vector6D computeMotionError();
   KDL::Frame m_target_frame;
   KDL::Frame m_current_frame;
+
+  bool target_available_;
+  
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::PoseStamped::SharedPtr> rt_buffer_ptr_;
 
   void targetFrameCallback(const geometry_msgs::msg::PoseStamped::SharedPtr target);
 

--- a/cartesian_motion_controller/src/cartesian_motion_controller.cpp
+++ b/cartesian_motion_controller/src/cartesian_motion_controller.cpp
@@ -43,7 +43,7 @@
 #include <cmath>
 
 #include "cartesian_controller_base/Utility.h"
-#include "controller_interface/controller_interface.hpp"
+#include "controller_interface/chainable_controller_interface.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
 
@@ -54,6 +54,7 @@ CartesianMotionController::CartesianMotionController() : Base::CartesianControll
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 CartesianMotionController::on_init()
 {
+  Base::controller_mode_ = true;
   const auto ret = Base::on_init();
   if (ret != rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS)
   {
@@ -71,6 +72,9 @@ CartesianMotionController::on_configure(const rclcpp_lifecycle::State & previous
   {
     return ret;
   }
+  target_available_ = false;
+
+  reference_interfaces_.resize(7, std::numeric_limits<double>::quiet_NaN());
 
   m_target_frame_subscr = get_node()->create_subscription<geometry_msgs::msg::PoseStamped>(
     get_node()->get_name() + std::string("/target_frame"), 3,
@@ -99,9 +103,18 @@ CartesianMotionController::on_deactivate(const rclcpp_lifecycle::State & previou
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::return_type CartesianMotionController::update(const rclcpp::Time & time,
-                                                                    const rclcpp::Duration & period)
+controller_interface::return_type CartesianMotionController::update_and_write_commands(
+  const rclcpp::Time & time, const rclcpp::Duration & period)
 {
+  if (Base::chained_mode_available_)
+  {
+    m_target_frame = KDL::Frame(
+      KDL::Rotation::Quaternion(Base::reference_interfaces_[3], Base::reference_interfaces_[4],
+                                Base::reference_interfaces_[5], Base::reference_interfaces_[6]),
+      KDL::Vector(Base::reference_interfaces_[0], Base::reference_interfaces_[1],
+                  Base::reference_interfaces_[2]));
+  }
+
   // Synchronize the internal model and the real robot
   Base::m_ik_solver->synchronizeJointPositions(Base::m_joint_state_pos_handles);
 
@@ -198,10 +211,28 @@ void CartesianMotionController::targetFrameCallback(
     return;
   }
 
-  m_target_frame = KDL::Frame(
-    KDL::Rotation::Quaternion(target->pose.orientation.x, target->pose.orientation.y,
-                              target->pose.orientation.z, target->pose.orientation.w),
-    KDL::Vector(target->pose.position.x, target->pose.position.y, target->pose.position.z));
+  rt_buffer_ptr_.writeFromNonRT(target);
+  target_available_ = true;
+}
+
+controller_interface::return_type CartesianMotionController::update_reference_from_subscribers()
+{
+  if (!this->isActive())
+  {
+    return controller_interface::return_type::OK;
+  }
+
+  if (target_available_)
+  {
+    auto target = rt_buffer_ptr_.readFromRT();
+    m_target_frame = KDL::Frame(
+      KDL::Rotation::Quaternion((*target)->pose.orientation.x, (*target)->pose.orientation.y,
+                                (*target)->pose.orientation.z, (*target)->pose.orientation.w),
+      KDL::Vector((*target)->pose.position.x, (*target)->pose.position.y,
+                  (*target)->pose.position.z));
+  }
+
+  return controller_interface::return_type::OK;
 }
 
 }  // namespace cartesian_motion_controller
@@ -210,4 +241,4 @@ void CartesianMotionController::targetFrameCallback(
 #include <pluginlib/class_list_macros.hpp>
 
 PLUGINLIB_EXPORT_CLASS(cartesian_motion_controller::CartesianMotionController,
-                       controller_interface::ControllerInterface)
+                       controller_interface::ChainableControllerInterface)


### PR DESCRIPTION
**Description:**

This pull request introduces the ability to chain controllers for Cartesian motion, force, and compliance controllers through reference interfaces. The functionality has been thoroughly tested in simulation for Cartesian motion controllers.

**Changes:**

Controller Chaining: Added the ability to chain controllers for Cartesian motion, force, and compliance controllers using reference interfaces.

**New Interfaces:**

1. Cartesian Motion Controller:

- cartesian_motion_controller/position.x

  - cartesian_motion_controller/position.y

  - cartesian_motion_controller/position.z

  - cartesian_motion_controller/orientation.x

  - cartesian_motion_controller/orientation.y

  - cartesian_motion_controller/orientation.z

  - cartesian_motion_controller/orientation.w

2. Cartesian Force Controller:

  - cartesian_force_controller/wrench.x

  - cartesian_force_controller/wrench.y

  - cartesian_force_controller/wrench.z

  - cartesian_force_controller/torque.x

  - cartesian_force_controller/torque.y

  - cartesian_force_controller/torque.z

3. Cartesian Compliance Controller:

  - cartesian_compliance_controller/torque.x

  - cartesian_compliance_controller/torque.y

  - cartesian_compliance_controller/torque.z

  - cartesian_compliance_controller/wrench.x

  - cartesian_compliance_controller/wrench.y

  - cartesian_compliance_controller/wrench.z
 
**Testing:** The controller chaining functionality has been tested in the simulation environment for the Cartesian motion controllers as shown in the provided video.
